### PR TITLE
*: make handshake be compatible with namespace

### DIFF
--- a/pkg/proxy/namespace/builder.go
+++ b/pkg/proxy/namespace/builder.go
@@ -19,7 +19,7 @@ type NamespaceImpl struct {
 	Br   driver.Breaker
 	Backend
 	Frontend
-	router      router.Router
+	router      driver.Router
 	rateLimiter *NamespaceRateLimiter
 }
 
@@ -70,11 +70,11 @@ func (n *NamespaceImpl) GetRateLimiter() driver.RateLimiter {
 	return n.rateLimiter
 }
 
-func (n *NamespaceImpl) GetRouter() router.Router {
+func (n *NamespaceImpl) GetRouter() driver.Router {
 	return n.router
 }
 
-func BuildRouter(cfg *config.BackendNamespace) (router.Router, error) {
+func BuildRouter(cfg *config.BackendNamespace) (driver.Router, error) {
 	if len(cfg.Instances) == 0 {
 		return nil, errors.New("no instances for the backend")
 	}

--- a/pkg/proxy/namespace/domain.go
+++ b/pkg/proxy/namespace/domain.go
@@ -17,6 +17,7 @@ type Namespace interface {
 	Close()
 	GetBreaker() (driver.Breaker, error)
 	GetRateLimiter() driver.RateLimiter
+	GetRouter() driver.Router
 }
 
 type Frontend interface {

--- a/pkg/proxy/namespace/namespace.go
+++ b/pkg/proxy/namespace/namespace.go
@@ -108,6 +108,10 @@ func (n *NamespaceWrapper) GetRateLimiter() driver.RateLimiter {
 	return n.mustGetCurrentNamespace().GetRateLimiter()
 }
 
+func (n *NamespaceWrapper) GetRouter() driver.Router {
+	return n.mustGetCurrentNamespace().GetRouter()
+}
+
 func (n *NamespaceWrapper) mustGetCurrentNamespace() Namespace {
 	ns, ok := n.nsmgr.getCurrentNamespaces().Get(n.name)
 	if !ok {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidb-incubator/weir/pkg/proxy/metrics"
 	"github.com/tidb-incubator/weir/pkg/proxy/namespace"
 	"github.com/tidb-incubator/weir/pkg/proxy/server"
+	"github.com/tidb-incubator/weir/pkg/proxy/sessionmgr/backend"
 	"github.com/tidb-incubator/weir/pkg/proxy/sessionmgr/client"
 )
 
@@ -53,7 +54,7 @@ func (p *Proxy) Init() error {
 		return err
 	}
 	p.nsmgr = nsmgr
-	driverImpl := driver.NewDriverImpl(nsmgr, client.NewClientConnectionImpl)
+	driverImpl := driver.NewDriverImpl(nsmgr, client.NewClientConnectionImpl, backend.NewBackendConnManager)
 	svr, err := server.NewServer(p.cfg, driverImpl)
 	if err != nil {
 		return err

--- a/pkg/proxy/router/router.go
+++ b/pkg/proxy/router/router.go
@@ -9,18 +9,12 @@ var (
 	ErrNoInstanceToSelect = errors.New("no instances to route")
 )
 
-type Router interface {
-	SetAddresses([]string)
-	Route() (string, error)
-	AddConnOnAddr(string, int)
-}
-
 type RandomRouter struct {
 	addresses  []string
 	addr2Conns map[string]int
 }
 
-func NewRandomRouter() Router {
+func NewRandomRouter() *RandomRouter {
 	return &RandomRouter{
 		addr2Conns: make(map[string]int, 0),
 	}

--- a/pkg/proxy/sessionmgr/backend/backend_conn.go
+++ b/pkg/proxy/sessionmgr/backend/backend_conn.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"github.com/siddontang/go-mysql/packet"
+	"github.com/tidb-incubator/weir/pkg/util/auth"
 )
 
 type connectionPhase byte
@@ -15,7 +16,7 @@ const (
 )
 
 type BackendConnection interface {
-	Connect(username string, authData []byte) error
+	Connect(authInfo *auth.AuthInfo) error
 	Close() error
 }
 
@@ -24,17 +25,17 @@ type BackendConnectionImpl struct {
 
 	phase      connectionPhase
 	capability uint32
-	server     *BackendServer
+	address    string
 }
 
-func NewBackendConnectionImpl(backendServer *BackendServer) *BackendConnectionImpl {
+func NewBackendConnectionImpl(address string) *BackendConnectionImpl {
 	return &BackendConnectionImpl{
-		phase:  handshaking,
-		server: backendServer,
+		phase:   handshaking,
+		address: address,
 	}
 }
 
-func (conn *BackendConnectionImpl) Connect(username string, authData []byte) error {
+func (conn *BackendConnectionImpl) Connect(authInfo *auth.AuthInfo) error {
 	return nil
 }
 

--- a/pkg/util/auth/auth_info.go
+++ b/pkg/util/auth/auth_info.go
@@ -1,0 +1,13 @@
+package auth
+
+// AuthInfo the user information that is stored temporarily in the proxy.
+type AuthInfo struct {
+	// user information obtained during authentication
+	Username    string
+	AuthPlugin  string
+	AuthString  []byte // password that sent from the client
+	BackendSalt []byte // backend salt used to encrypt password
+	Token       []byte // or password
+
+	DefaultDB string
+}


### PR DESCRIPTION
Previously, when a client handshakes with the proxy, the proxy can just connect to one server immediately.
Now that we have namespaces (or multi-tenancy), the proxy doesn't know which backend server to connect to until it receives the username.
This PR delays the backend connection after the router chooses one backend server.