### PR TITLE
sessionmgr: handshake and forward msg between client and server

### DIFF
--- a/pkg/proxy/driver/domain.go
+++ b/pkg/proxy/driver/domain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
 	"github.com/siddontang/go-mysql/mysql"
+	pnet "github.com/tidb-incubator/weir/pkg/proxy/net"
 	wauth "github.com/tidb-incubator/weir/pkg/util/auth"
 )
 
@@ -104,7 +105,8 @@ type ClientConnection interface {
 
 type BackendConnManager interface {
 	SetAuthInfo(authInfo *wauth.AuthInfo)
-	Connect(address string) error
+	Connect(ctx context.Context, serverAddr string, clientIO *pnet.PacketIO) error
+	ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error
 	Query(ctx context.Context, sql string) (*mysql.Result, error)
 	Close() error
 }
@@ -126,8 +128,12 @@ type QueryCtx interface {
 	// Execute executes a SQL statement.
 	Execute(ctx context.Context, sql string) (*mysql.Result, error)
 
+	ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error
+
 	// Close closes the QueryCtx.
 	Close() error
+
+	ConnectBackend(ctx context.Context, clientIO *pnet.PacketIO) error
 
 	// Auth verifies user's authentication.
 	Auth(user *auth.UserIdentity, auth []byte, salt []byte) error

--- a/pkg/proxy/namespace/user.go
+++ b/pkg/proxy/namespace/user.go
@@ -30,6 +30,12 @@ func CreateUserNamespaceMapper(namespaces []*config.Namespace) (*UserNamespaceMa
 }
 
 func (u *UserNamespaceMapper) GetUserNamespace(username string) (string, bool) {
+	if username == "" {
+		for _, ns := range u.userToNamespace {
+			return ns, true
+		}
+	}
+
 	ns, ok := u.userToNamespace[username]
 	return ns, ok
 }

--- a/pkg/proxy/sessionmgr/backend/backend_conn.go
+++ b/pkg/proxy/sessionmgr/backend/backend_conn.go
@@ -1,8 +1,13 @@
 package backend
 
 import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/pingcap/tidb/util/arena"
 	"github.com/siddontang/go-mysql/packet"
-	"github.com/tidb-incubator/weir/pkg/util/auth"
+	pnet "github.com/tidb-incubator/weir/pkg/proxy/net"
 )
 
 type connectionPhase byte
@@ -16,12 +21,16 @@ const (
 )
 
 type BackendConnection interface {
-	Connect(authInfo *auth.AuthInfo) error
+	Connect() error
+	PacketIO() *pnet.PacketIO
 	Close() error
 }
 
 type BackendConnectionImpl struct {
 	*packet.Conn
+	pkt         *pnet.PacketIO         // a helper to read and write data in packet format.
+	bufReadConn *pnet.BufferedReadConn // a buffered-read net.Conn or buffered-read tls.Conn.
+	alloc       arena.Allocator
 
 	phase      connectionPhase
 	capability uint32
@@ -32,13 +41,27 @@ func NewBackendConnectionImpl(address string) *BackendConnectionImpl {
 	return &BackendConnectionImpl{
 		phase:   handshaking,
 		address: address,
+		alloc:   arena.NewAllocator(32 * 1024),
 	}
 }
 
-func (conn *BackendConnectionImpl) Connect(authInfo *auth.AuthInfo) error {
+func (bc *BackendConnectionImpl) Connect() error {
+	cn, err := net.DialTimeout("tcp", bc.address, time.Second*5)
+	if err != nil {
+		return errors.New("dial backend error")
+	}
+
+	bufReadConn := pnet.NewBufferedReadConn(cn)
+	pkt := pnet.NewPacketIO(bufReadConn)
+	bc.bufReadConn = bufReadConn
+	bc.pkt = pkt
 	return nil
 }
 
-func (conn *BackendConnectionImpl) Close() error {
+func (bc *BackendConnectionImpl) PacketIO() *pnet.PacketIO {
+	return bc.pkt
+}
+
+func (bc *BackendConnectionImpl) Close() error {
 	return nil
 }

--- a/pkg/proxy/sessionmgr/backend/backend_conn_mgr.go
+++ b/pkg/proxy/sessionmgr/backend/backend_conn_mgr.go
@@ -3,8 +3,10 @@ package backend
 import (
 	"context"
 
+	"github.com/pingcap/parser/mysql"
 	gomysql "github.com/siddontang/go-mysql/mysql"
 	"github.com/tidb-incubator/weir/pkg/proxy/driver"
+	pnet "github.com/tidb-incubator/weir/pkg/proxy/net"
 	"github.com/tidb-incubator/weir/pkg/util/auth"
 )
 
@@ -56,15 +58,120 @@ func (mgr *BackendConnManager) SetAuthInfo(authInfo *auth.AuthInfo) {
 	mgr.authInfo = authInfo
 }
 
-func (mgr *BackendConnManager) Connect(address string) error {
+func (mgr *BackendConnManager) Connect(ctx context.Context, serverAddr string, clientIO *pnet.PacketIO) error {
 	// It may be still connecting to the original backend server.
 	if mgr.backendConn != nil {
 		if err := mgr.backendConn.Close(); err != nil {
 			return err
 		}
 	}
-	mgr.backendConn = NewBackendConnectionImpl(address)
-	return mgr.backendConn.Connect(mgr.authInfo)
+	mgr.backendConn = NewBackendConnectionImpl(serverAddr)
+	err := mgr.backendConn.Connect()
+	if err != nil {
+		return err
+	}
+	backendIO := mgr.backendConn.PacketIO()
+	return mgr.handshake(ctx, clientIO, backendIO)
+}
+
+func (mgr *BackendConnManager) handshake(ctx context.Context, clientIO, backendIO *pnet.PacketIO) error {
+	backendIO.ResetSequence()
+	for {
+		serverPkt, err := backendIO.ReadPacket()
+		if err != nil {
+			return err
+		}
+		err = clientIO.WritePacket(serverPkt)
+		if err != nil {
+			return err
+		}
+		err = clientIO.Flush()
+		if err != nil {
+			return err
+		}
+		// Authentication finished.
+		if len(serverPkt) > 1 {
+			finished := false
+			switch serverPkt[0] {
+			case mysql.OKHeader, mysql.ErrHeader:
+				finished = true
+			case mysql.EOFHeader:
+				// EOFHeader == AuthSwitchRequest. Not possible to send EOF now.
+			}
+			if finished {
+				break
+			}
+		}
+		clientPkt, err := clientIO.ReadPacket()
+		if err != nil {
+			return err
+		}
+		err = backendIO.WritePacket(clientPkt)
+		if err != nil {
+			return err
+		}
+		err = backendIO.Flush()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error {
+	backendIO := mgr.backendConn.PacketIO()
+	backendIO.ResetSequence()
+	err := backendIO.WritePacket(request)
+	if err != nil {
+		return nil
+	}
+	err = backendIO.Flush()
+	if err != nil {
+		return err
+	}
+	cmd := request[0]
+	switch cmd {
+	case mysql.ComQuery:
+		return mgr.forwardCommand(ctx, clientIO, backendIO, 2)
+	case mysql.ComQuit:
+		return nil
+	default:
+		return mgr.forwardCommand(ctx, clientIO, backendIO, 1)
+	}
+}
+
+func (mgr *BackendConnManager) forwardCommand(ctx context.Context, clientIO, backendIO *pnet.PacketIO, expectedEOFNum int) error {
+	eofHeaders := 0
+	okOrErr := false
+	for eofHeaders < expectedEOFNum && !okOrErr {
+		data, err := backendIO.ReadPacket()
+		if err != nil {
+			return err
+		}
+		switch data[0] {
+		case mysql.OKHeader:
+			mgr.handleOKPacket(data)
+			okOrErr = true
+		case mysql.ErrHeader:
+			okOrErr = true
+		case mysql.EOFHeader:
+			if len(data) <= 5 {
+				mgr.handleEOFPacket(data)
+				eofHeaders += 1
+			}
+		}
+		err = clientIO.WritePacket(data)
+		if err != nil {
+			return err
+		}
+	}
+	return clientIO.Flush()
+}
+
+func (mgr *BackendConnManager) handleOKPacket(data []byte) {
+}
+
+func (mgr *BackendConnManager) handleEOFPacket(data []byte) {
 }
 
 func (mgr *BackendConnManager) initSessionStates() error {

--- a/pkg/proxy/sessionmgr/client/handshake.go
+++ b/pkg/proxy/sessionmgr/client/handshake.go
@@ -35,6 +35,14 @@ var (
 )
 
 func (cc *ClientConnectionImpl) handshake(ctx context.Context) error {
+	if err := cc.queryCtx.ConnectBackend(ctx, cc.pkt); err != nil {
+		return err
+	}
+	cc.pkt.ResetSequence()
+	return nil
+}
+
+func (cc *ClientConnectionImpl) handshake1(ctx context.Context) error {
 	if err := cc.writeInitialHandshake(); err != nil {
 		if errors.Cause(err) == io.EOF {
 			logutil.Logger(ctx).Debug("Could not send handshake due to connection has be closed by client-side")


### PR DESCRIPTION
This PR does 2 things:
- Forward the handshake packets when the client connects to the server for the first time. The proxy is not aware of the information in the packets. It just checks if it's done.
- Forward the commands and responses between the client and the server. The proxy won't parse the whole message. It just checks the header to decide whether to finish.