### PR TITLE
backend: support TLS connection

### DIFF
--- a/cmd/weirproxy/main.go
+++ b/cmd/weirproxy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/djshow832/weir/pkg/util/disk"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -30,6 +31,12 @@ func main() {
 	proxyCfg, err := config.UnmarshalProxyConfig(proxyConfigData)
 	if err != nil {
 		fmt.Printf("parse config file error: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = disk.InitializeTempDir(proxyCfg.ProxyServer.StoragePath)
+	if err != nil {
+		fmt.Printf("initialize temporary path error: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/conf/weirproxy.yaml
+++ b/conf/weirproxy.yaml
@@ -3,6 +3,7 @@ proxy_server:
   addr: "0.0.0.0:6000"
   max_connections: 1000
   session_timeout: 600
+  storage_path: "/tmp/weir"
 admin_server:
   addr: "0.0.0.0:6001"
   enable_basic_auth: false
@@ -25,3 +26,5 @@ config_center:
     strict_parse: false
 performance:
   tcp_keep_alive: true
+security:
+  rsa-key-size: 4096

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/djshow832/weir
 go 1.16
 
 require (
+	github.com/danjacques/gofslock v0.0.0-20191023191349-0a45f885bc37
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-playground/validator/v10 v10.8.0 // indirect
 	github.com/goccy/go-yaml v1.8.2

--- a/pkg/config/proxy.go
+++ b/pkg/config/proxy.go
@@ -17,12 +17,14 @@ type Proxy struct {
 	Registry     Registry     `yaml:"registry"`
 	ConfigCenter ConfigCenter `yaml:"config_center"`
 	Performance  Performance  `yaml:"performance"`
+	Security     Security     `yaml:"security"`
 }
 
 type ProxyServer struct {
 	Addr           string `yaml:"addr"`
 	MaxConnections uint32 `yaml:"max_connections"`
 	SessionTimeout int    `yaml:"session_timeout"`
+	StoragePath    string `yaml:"storage_path"`
 }
 
 type AdminServer struct {
@@ -72,4 +74,16 @@ type ConfigEtcd struct {
 
 type Performance struct {
 	TCPKeepAlive bool `yaml:"tcp_keep_alive"`
+}
+
+type Security struct {
+	SSLCA           string   `toml:"ssl-ca" json:"ssl-ca"`
+	SSLCert         string   `toml:"ssl-cert" json:"ssl-cert"`
+	SSLKey          string   `toml:"ssl-key" json:"ssl-key"`
+	ClusterSSLCA    string   `toml:"cluster-ssl-ca" json:"cluster-ssl-ca"`
+	ClusterSSLCert  string   `toml:"cluster-ssl-cert" json:"cluster-ssl-cert"`
+	ClusterSSLKey   string   `toml:"cluster-ssl-key" json:"cluster-ssl-key"`
+	ClusterVerifyCN []string `toml:"cluster-verify-cn" json:"cluster-verify-cn"`
+	MinTLSVersion   string   `toml:"tls-version" json:"tls-version"`
+	RSAKeySize      int      `toml:"rsa-key-size" json:"rsa-key-size"`
 }

--- a/pkg/proxy/driver/domain.go
+++ b/pkg/proxy/driver/domain.go
@@ -61,14 +61,14 @@ type ClientConnection interface {
 }
 
 type BackendConnManager interface {
-	Connect(ctx context.Context, serverAddr string, clientIO *pnet.PacketIO) error
+	Connect(ctx context.Context, serverAddr string, clientIO *pnet.PacketIO, tlsConfig *tls.Config) error
 	ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error
 	Close() error
 }
 
 // QueryCtx is the interface to execute command.
 type QueryCtx interface {
-	ConnectBackend(ctx context.Context, clientIO *pnet.PacketIO) error
+	ConnectBackend(ctx context.Context, clientIO *pnet.PacketIO, tlsConfig *tls.Config) error
 
 	ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error
 
@@ -78,5 +78,4 @@ type QueryCtx interface {
 
 type IDriver interface {
 	CreateClientConnection(conn net.Conn, connectionID uint64, tlsConfig *tls.Config) ClientConnection
-	CreateBackendConnManager() BackendConnManager
 }

--- a/pkg/proxy/driver/driver.go
+++ b/pkg/proxy/driver/driver.go
@@ -27,7 +27,3 @@ func (d *DriverImpl) CreateClientConnection(conn net.Conn, connectionID uint64, 
 	queryCtx := NewQueryCtxImpl(d.nsmgr, backendConnMgr, connectionID)
 	return d.createClientConnFunc(queryCtx, conn, connectionID, tlsConfig)
 }
-
-func (d *DriverImpl) CreateBackendConnManager() BackendConnManager {
-	return d.createBackendConnMgrFunc()
-}

--- a/pkg/proxy/driver/queryctx.go
+++ b/pkg/proxy/driver/queryctx.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 
 	pnet "github.com/djshow832/weir/pkg/proxy/net"
@@ -55,7 +56,7 @@ func (q *QueryCtxImpl) Close() error {
 	return nil
 }
 
-func (q *QueryCtxImpl) ConnectBackend(ctx context.Context, clientIO *pnet.PacketIO) error {
+func (q *QueryCtxImpl) ConnectBackend(ctx context.Context, clientIO *pnet.PacketIO, tlsConfig *tls.Config) error {
 	ns, ok := q.nsmgr.Auth("", nil, nil)
 	if !ok {
 		return errors.New("failed to find a namespace")
@@ -65,7 +66,7 @@ func (q *QueryCtxImpl) ConnectBackend(ctx context.Context, clientIO *pnet.Packet
 	if err != nil {
 		return err
 	}
-	if err = q.connMgr.Connect(ctx, addr, clientIO); err != nil {
+	if err = q.connMgr.Connect(ctx, addr, clientIO, tlsConfig); err != nil {
 		return err
 	}
 	q.ns.IncrConnCount()

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -36,6 +36,7 @@ package net
 
 import (
 	"bufio"
+	"crypto/tls"
 	"io"
 	"time"
 
@@ -180,4 +181,24 @@ func (p *PacketIO) Flush() error {
 		return errors.Trace(err)
 	}
 	return err
+}
+
+func (p *PacketIO) UpgradeToServerTLS(tlsConfig *tls.Config) error {
+	tlsConn := tls.Server(p.bufReadConn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		return err
+	}
+	bufReadConn := NewBufferedReadConn(tlsConn)
+	p.SetBufferedReadConn(bufReadConn)
+	return nil
+}
+
+func (p *PacketIO) UpgradeToClientTLS(tlsConfig *tls.Config) error {
+	tlsConn := tls.Client(p.bufReadConn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		return err
+	}
+	bufReadConn := NewBufferedReadConn(tlsConn)
+	p.SetBufferedReadConn(bufReadConn)
+	return nil
 }

--- a/pkg/proxy/sessionmgr/backend/backend_server.go
+++ b/pkg/proxy/sessionmgr/backend/backend_server.go
@@ -1,9 +1,0 @@
-package backend
-
-type BackendServer struct {
-	addr string
-}
-
-func (server *BackendServer) Addr() string {
-	return server.addr
-}

--- a/pkg/proxy/sessionmgr/client/client_conn.go
+++ b/pkg/proxy/sessionmgr/client/client_conn.go
@@ -18,7 +18,6 @@ import (
 )
 
 type ClientConnectionImpl struct {
-	tlsConn      *tls.Conn // TLS connection, nil if not TLS.
 	tlsConfig    *tls.Config
 	pkt          *pnet.PacketIO         // a helper to read and write data in packet format.
 	bufReadConn  *pnet.BufferedReadConn // a buffered-read net.Conn or buffered-read tls.Conn.
@@ -53,7 +52,7 @@ func (cc *ClientConnectionImpl) Auth() error {
 }
 
 func (cc *ClientConnectionImpl) Run(ctx context.Context) {
-	if err := cc.queryCtx.ConnectBackend(ctx, cc.pkt); err != nil {
+	if err := cc.queryCtx.ConnectBackend(ctx, cc.pkt, cc.tlsConfig); err != nil {
 		logutil.Logger(ctx).Info("new connection fails", zap.String("remoteAddr", cc.Addr()), zap.Error(err))
 		metrics.HandShakeErrorCounter.Inc()
 		err = cc.Close()


### PR DESCRIPTION
This PR supports TLS connection between client <-> proxy and proxy <-> TiDB. When the client requests a TLS connection, the proxy establishes 2 TLS connections.

The certificate is not supported to be reloaded yet. I'll do it in a future version.

Besides:
- Added package `security` to create certificates and TLS configs.
- Added package `disk` to create a temporary storage path.
- Added some configuration items to support security configurations.