### PR TITLE
api, backend: support sending redirect command

### DIFF
--- a/pkg/proxy/driver/domain.go
+++ b/pkg/proxy/driver/domain.go
@@ -57,12 +57,14 @@ type ClientConnection interface {
 	ConnectionID() uint64
 	Addr() string
 	Run(context.Context)
+	Redirect() error
 	Close() error
 }
 
 type BackendConnManager interface {
 	Connect(ctx context.Context, serverAddr string, clientIO *pnet.PacketIO, tlsConfig *tls.Config) error
 	ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error
+	Redirect(newAddr string, tlsConfig *tls.Config) error
 	Close() error
 }
 
@@ -71,6 +73,8 @@ type QueryCtx interface {
 	ConnectBackend(ctx context.Context, clientIO *pnet.PacketIO, tlsConfig *tls.Config) error
 
 	ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error
+
+	Redirect(tlsConfig *tls.Config) error
 
 	// Close closes the QueryCtx.
 	Close() error

--- a/pkg/proxy/driver/queryctx.go
+++ b/pkg/proxy/driver/queryctx.go
@@ -47,11 +47,11 @@ func (q *QueryCtxImpl) ExecuteCmd(ctx context.Context, request []byte, clientIO 
 }
 
 func (q *QueryCtxImpl) Close() error {
-	if q.ns != nil {
-		q.ns.DescConnCount()
-	}
 	if q.connMgr != nil {
 		return q.connMgr.Close()
+	}
+	if q.ns != nil {
+		q.ns.DescConnCount()
 	}
 	return nil
 }
@@ -70,5 +70,16 @@ func (q *QueryCtxImpl) ConnectBackend(ctx context.Context, clientIO *pnet.Packet
 		return err
 	}
 	q.ns.IncrConnCount()
+	return nil
+}
+
+func (q *QueryCtxImpl) Redirect(tlsConfig *tls.Config) error {
+	addr, err := q.ns.GetRouter().Route()
+	if err != nil {
+		return err
+	}
+	if err = q.connMgr.Redirect(addr, tlsConfig); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/proxy/server/server.go
+++ b/pkg/proxy/server/server.go
@@ -227,3 +227,15 @@ func (s *Server) TryGracefulDown() {
 func (s *Server) GracefulDown(ctx context.Context, done chan struct{}) {
 	return
 }
+
+func (s *Server) RedirectConnections() error {
+	s.rwlock.RLock()
+	defer s.rwlock.RUnlock()
+	for _, conn := range s.clients {
+		err := conn.Redirect()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/proxy/sessionmgr/backend/handshake.go
+++ b/pkg/proxy/sessionmgr/backend/handshake.go
@@ -16,8 +16,6 @@ import (
 const ShaCommand = 1
 
 type Authenticator struct {
-	clientTLS  *tls.Config
-	serverTLS  *tls.Config
 	user       string
 	authData   []byte // password
 	authPlugin string
@@ -55,6 +53,7 @@ func (auth *Authenticator) handshakeWithClient(ctx context.Context, clientIO, ba
 	// A 2-bytes capability contains the ClientSSL flag, no matter ClientProtocol41 is set or not.
 	if capability&mysql.ClientSSL > 0 {
 		// Upgrade with the client.
+		serverTLSConfig = serverTLSConfig.Clone()
 		err = clientIO.UpgradeToServerTLS(serverTLSConfig)
 		if err != nil {
 			return false, err

--- a/pkg/proxy/sessionmgr/client/client_conn.go
+++ b/pkg/proxy/sessionmgr/client/client_conn.go
@@ -81,13 +81,12 @@ func (cc *ClientConnectionImpl) processMsg(ctx context.Context) error {
 		switch cmd {
 		case mysql.ComQuery:
 			var data []byte
-			var dataStr string
 			if len(clientPkt) > 1 && clientPkt[len(clientPkt)-1] == 0 {
 				data = clientPkt[1 : len(clientPkt)-1]
 			} else {
 				data = clientPkt[1:]
 			}
-			dataStr = string(hack.String(data))
+			dataStr := string(hack.String(data))
 			logutil.Logger(ctx).Info("receive cmd", zap.String("query", dataStr))
 		case mysql.ComQuit:
 			logutil.Logger(ctx).Info("quit")
@@ -102,6 +101,10 @@ func (cc *ClientConnectionImpl) processMsg(ctx context.Context) error {
 	}
 }
 
+func (cc *ClientConnectionImpl) Redirect() error {
+	return cc.queryCtx.Redirect(cc.tlsConfig)
+}
+
 func (cc *ClientConnectionImpl) Close() error {
-	return nil
+	return cc.queryCtx.Close()
 }


### PR DESCRIPTION
What's changed:
- Add a HTTP handler to process `/test/redirect`. It sends a redirect command to all connections.
- In `BackendConnManager`, there's a goroutine checking redirect signals. It will choose a proper time to redirect connections.

Test:
1. Start a MySQL client connection:
```
mysql -h127.1 -uroot -P6000
mysql>
```

2. Send a POST command to the HTTP API:
```
curl -X POST http://127.0.0.1:6001/test/redirect
```

3. Check the log:
```
["trying to redirect connection "] [conn=1] [to=127.0.0.1:4000]
```