### PR TITLE
backend: support reconnecting to server with caching_sha2_password

### DIFF
--- a/pkg/proxy/driver/domain.go
+++ b/pkg/proxy/driver/domain.go
@@ -64,7 +64,7 @@ type ClientConnection interface {
 type BackendConnManager interface {
 	Connect(ctx context.Context, serverAddr string, clientIO *pnet.PacketIO, tlsConfig *tls.Config) error
 	ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error
-	Redirect(newAddr string, tlsConfig *tls.Config) error
+	Redirect(newAddr string) error
 	Close() error
 }
 
@@ -74,7 +74,7 @@ type QueryCtx interface {
 
 	ExecuteCmd(ctx context.Context, request []byte, clientIO *pnet.PacketIO) error
 
-	Redirect(tlsConfig *tls.Config) error
+	Redirect() error
 
 	// Close closes the QueryCtx.
 	Close() error

--- a/pkg/proxy/driver/queryctx.go
+++ b/pkg/proxy/driver/queryctx.go
@@ -73,12 +73,12 @@ func (q *QueryCtxImpl) ConnectBackend(ctx context.Context, clientIO *pnet.Packet
 	return nil
 }
 
-func (q *QueryCtxImpl) Redirect(tlsConfig *tls.Config) error {
+func (q *QueryCtxImpl) Redirect() error {
 	addr, err := q.ns.GetRouter().Route()
 	if err != nil {
 		return err
 	}
-	if err = q.connMgr.Redirect(addr, tlsConfig); err != nil {
+	if err = q.connMgr.Redirect(addr); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -186,7 +186,7 @@ func (p *PacketIO) Flush() error {
 func (p *PacketIO) UpgradeToServerTLS(tlsConfig *tls.Config) error {
 	tlsConn := tls.Server(p.bufReadConn, tlsConfig)
 	if err := tlsConn.Handshake(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	bufReadConn := NewBufferedReadConn(tlsConn)
 	p.SetBufferedReadConn(bufReadConn)
@@ -196,7 +196,7 @@ func (p *PacketIO) UpgradeToServerTLS(tlsConfig *tls.Config) error {
 func (p *PacketIO) UpgradeToClientTLS(tlsConfig *tls.Config) error {
 	tlsConn := tls.Client(p.bufReadConn, tlsConfig)
 	if err := tlsConn.Handshake(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	bufReadConn := NewBufferedReadConn(tlsConn)
 	p.SetBufferedReadConn(bufReadConn)

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -202,3 +202,7 @@ func (p *PacketIO) UpgradeToClientTLS(tlsConfig *tls.Config) error {
 	p.SetBufferedReadConn(bufReadConn)
 	return nil
 }
+
+func (p *PacketIO) Close() error {
+	return p.bufReadConn.Close()
+}

--- a/pkg/proxy/sessionmgr/backend/backend_conn.go
+++ b/pkg/proxy/sessionmgr/backend/backend_conn.go
@@ -26,12 +26,11 @@ type BackendConnection interface {
 }
 
 type BackendConnectionImpl struct {
-	pkt         *pnet.PacketIO         // a helper to read and write data in packet format.
-	bufReadConn *pnet.BufferedReadConn // a buffered-read net.Conn or buffered-read tls.Conn.
-	alloc       arena.Allocator
-	phase       connectionPhase
-	capability  uint32
-	address     string
+	pkt        *pnet.PacketIO // a helper to read and write data in packet format.
+	alloc      arena.Allocator
+	phase      connectionPhase
+	capability uint32
+	address    string
 }
 
 func NewBackendConnectionImpl(address string) *BackendConnectionImpl {
@@ -50,7 +49,6 @@ func (bc *BackendConnectionImpl) Connect() error {
 
 	bufReadConn := pnet.NewBufferedReadConn(cn)
 	pkt := pnet.NewPacketIO(bufReadConn)
-	bc.bufReadConn = bufReadConn
 	bc.pkt = pkt
 	return nil
 }
@@ -60,5 +58,5 @@ func (bc *BackendConnectionImpl) PacketIO() *pnet.PacketIO {
 }
 
 func (bc *BackendConnectionImpl) Close() error {
-	return nil
+	return bc.pkt.Close()
 }

--- a/pkg/proxy/sessionmgr/backend/backend_conn_mgr.go
+++ b/pkg/proxy/sessionmgr/backend/backend_conn_mgr.go
@@ -194,13 +194,13 @@ func (mgr *BackendConnManager) tryProcessSignal(ctx context.Context) error {
 	}
 	backendIO := backendConn.PacketIO()
 	// Retrial may be needed in the future.
-	err = mgr.authenticator.handshakeWithServer(context.Background(), backendIO)
+	err = mgr.authenticator.handshakeWithServer(ctx, backendIO)
 	if err == nil {
 		logutil.Logger(ctx).Info("redirect connection succeeds", zap.String("to", signal.newAddr))
-		mgr.backendConn = backendConn
 		if err := mgr.backendConn.Close(); err != nil {
-			logutil.Logger(ctx).Info("close old connection failed", zap.Error(err))
+			logutil.Logger(ctx).Warn("close old connection failed", zap.Error(err))
 		}
+		mgr.backendConn = backendConn
 	}
 
 	mgr.signalLock.Lock()
@@ -228,5 +228,5 @@ func (mgr *BackendConnManager) Redirect(newAddr string) error {
 }
 
 func (mgr *BackendConnManager) Close() error {
-	return nil
+	return mgr.backendConn.Close()
 }

--- a/pkg/proxy/sessionmgr/backend/backend_conn_mgr.go
+++ b/pkg/proxy/sessionmgr/backend/backend_conn_mgr.go
@@ -29,8 +29,7 @@ const (
 )
 
 type signalRedirect struct {
-	tlsConfig *tls.Config
-	newAddr   string
+	newAddr string
 }
 
 type BackendConnManager struct {
@@ -186,10 +185,23 @@ func (mgr *BackendConnManager) tryProcessSignal(ctx context.Context) error {
 		}
 	}
 
-	backendIO := mgr.backendConn.PacketIO()
-	logutil.Logger(ctx).Info("trying to redirect connection ", zap.String("to", signal.newAddr))
+	logutil.Logger(ctx).Info("trying to redirect connection", zap.String("to", signal.newAddr))
+	backendConn := NewBackendConnectionImpl(signal.newAddr)
+	err := backendConn.Connect()
+	if err != nil {
+		mgr.connPhase = Command
+		return err
+	}
+	backendIO := backendConn.PacketIO()
 	// Retrial may be needed in the future.
-	err := mgr.authenticator.handshakeWithServer(context.Background(), backendIO)
+	err = mgr.authenticator.handshakeWithServer(context.Background(), backendIO)
+	if err == nil {
+		logutil.Logger(ctx).Info("redirect connection succeeds", zap.String("to", signal.newAddr))
+		mgr.backendConn = backendConn
+		if err := mgr.backendConn.Close(); err != nil {
+			logutil.Logger(ctx).Info("close old connection failed", zap.Error(err))
+		}
+	}
 
 	mgr.signalLock.Lock()
 	// Check mgr.signal because it may be updated again.
@@ -202,11 +214,10 @@ func (mgr *BackendConnManager) tryProcessSignal(ctx context.Context) error {
 	return err
 }
 
-func (mgr *BackendConnManager) Redirect(newAddr string, tlsConfig *tls.Config) error {
+func (mgr *BackendConnManager) Redirect(newAddr string) error {
 	mgr.signalLock.Lock()
 	mgr.signal = &signalRedirect{
-		newAddr:   newAddr,
-		tlsConfig: tlsConfig,
+		newAddr: newAddr,
 	}
 	mgr.signalLock.Unlock()
 	select {

--- a/pkg/proxy/sessionmgr/backend/handshake.go
+++ b/pkg/proxy/sessionmgr/backend/handshake.go
@@ -8,12 +8,19 @@ import (
 	"fmt"
 
 	pnet "github.com/djshow832/weir/pkg/proxy/net"
+	"github.com/djshow832/weir/pkg/util/passwd"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
 )
 
-const ShaCommand = 1
+const (
+	ShaCommand       = 1
+	RequestRsaPubKey = 2
+	FastAuthOk       = 3
+	FastAuthFail     = 4
+)
 
 type Authenticator struct {
 	user       string
@@ -79,6 +86,7 @@ func (auth *Authenticator) handshakeWithClient(ctx context.Context, clientIO, ba
 		}
 		switch serverPkt[0] {
 		case mysql.OKHeader:
+			logutil.BgLogger().Info("parse client handshake response finished", zap.String("authInfo", auth.String()))
 			return true, nil
 		case mysql.ErrHeader:
 			return false, nil
@@ -124,7 +132,6 @@ func (auth *Authenticator) readHandshakeResponse(data []byte) {
 	} else {
 		auth.parseOldHandshakeResponse(data)
 	}
-	logutil.BgLogger().Info("parse client handshake response finished", zap.String("authInfo", auth.String()))
 }
 
 func (auth *Authenticator) parseHandshakeResponse(data []byte) {
@@ -220,5 +227,209 @@ func (auth *Authenticator) parseOldHandshakeResponse(data []byte) {
 }
 
 func (auth *Authenticator) handshakeWithServer(ctx context.Context, backendIO *pnet.PacketIO) error {
-	return nil
+	if auth.authPlugin != mysql.AuthCachingSha2Password {
+		return errors.New(fmt.Sprintf("only support %s now", mysql.AuthCachingSha2Password))
+	}
+
+	salt, capability, authPlugin, err := auth.readInitialHandshake(backendIO)
+	if err != nil {
+		return err
+	}
+
+	err = auth.writeAuthHandshake(backendIO, salt, capability, authPlugin)
+	if err != nil {
+		return err
+	}
+
+	return auth.handleAuthResult(backendIO)
+}
+
+func (auth *Authenticator) readInitialHandshake(backendIO *pnet.PacketIO) (salt []byte, capability uint32, authPlugin string, err error) {
+	data, err := backendIO.ReadPacket()
+	if err != nil {
+		return nil, 0, "", errors.Trace(err)
+	}
+
+	if data[0] == mysql.ErrHeader {
+		return nil, 0, "", errors.New("read initial handshake error")
+	}
+
+	// Skip mysql version, mysql version end with 0x00.
+	pos := 1 + bytes.IndexByte(data[1:], 0x00) + 1
+
+	// skip connection id
+	pos += 4
+	salt = append(salt, data[pos:pos+8]...)
+
+	// skip filter
+	pos += 8 + 1
+	// capability lower 2 bytes
+	capability = uint32(binary.LittleEndian.Uint16(data[pos : pos+2]))
+	pos += 2
+
+	if len(data) > pos {
+		// skip server charset + status
+		pos += 1 + 2
+		// capability flags (upper 2 bytes)
+		capability = uint32(binary.LittleEndian.Uint16(data[pos:pos+2]))<<16 | capability
+		pos += 2
+
+		// skip auth data len or [00]
+		// skip reserved (all [00])
+		pos += 10 + 1
+		salt = append(salt, data[pos:pos+12]...)
+		pos += 13
+
+		// auth plugin
+		if end := bytes.IndexByte(data[pos:], 0x00); end != -1 {
+			authPlugin = string(data[pos : pos+end])
+		} else {
+			authPlugin = string(data[pos:])
+		}
+	}
+	return
+}
+
+func (auth *Authenticator) writeAuthHandshake(backendIO *pnet.PacketIO, salt []byte, serverCapability uint32, authPlugin string) error {
+	authData := passwd.CalculatePassword(salt, auth.authData, auth.authPlugin)
+
+	// encode length of the auth plugin data
+	var authRespBuf [9]byte
+	authResp := pnet.DumpLengthEncodedInt(authRespBuf[:0], uint64(len(authData)))
+	capability := auth.capability
+	if len(authResp) > 1 {
+		capability |= mysql.ClientPluginAuthLenencClientData
+	} else {
+		capability &= ^mysql.ClientPluginAuthLenencClientData
+	}
+
+	//packet length
+	//capability 4
+	//max-packet size 4
+	//charset 1
+	//reserved all[0] 23
+	//username
+	//auth
+	//mysql_native_password + null-terminated
+	length := 4 + 4 + 1 + 23 + len(auth.user) + 1 + len(authResp) + len(authData) + 21 + 1
+	// db name
+	if len(auth.dbname) > 0 {
+		length += len(auth.dbname) + 1
+	}
+
+	data := make([]byte, length)
+	pos := 0
+
+	// capability [32 bit]
+	pnet.DumpUint32(data[:0], capability)
+	pos += 4
+
+	// MaxPacketSize [32 bit] (none)
+	for i := 0; i < 4; i++ {
+		data[pos] = 0x00
+		pos++
+	}
+
+	// Charset [1 byte]
+	data[pos] = auth.collation
+	pos++
+
+	// Filler [23 bytes] (all 0x00)
+	for i := 0; i < 23; i++ {
+		data[pos] = 0
+		pos++
+	}
+
+	var err error
+	// SSL Connection Request Packet
+	if serverCapability&mysql.ClientSSL > 0 {
+		// Send TLS / SSL request packet
+		if err = backendIO.WritePacket(data[:pos]); err != nil {
+			return err
+		}
+		if err = backendIO.Flush(); err != nil {
+			return err
+		}
+		if err = backendIO.UpgradeToClientTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
+			return err
+		}
+	}
+
+	// User [null terminated string]
+	if len(auth.user) > 0 {
+		pos += copy(data[pos:], auth.user)
+	}
+	data[pos] = 0x00
+	pos++
+
+	// auth [length encoded integer]
+	pos += copy(data[pos:], authResp)
+	pos += copy(data[pos:], authData)
+
+	// db [null terminated string]
+	if len(auth.dbname) > 0 {
+		pos += copy(data[pos:], auth.dbname)
+		data[pos] = 0x00
+		pos++
+	}
+
+	// Assume native client during response
+	pos += copy(data[pos:], auth.authPlugin)
+	data[pos] = 0x00
+
+	if err = backendIO.WritePacket(data); err != nil {
+		return err
+	}
+	return backendIO.Flush()
+}
+
+func (auth *Authenticator) handleAuthResult(backendIO *pnet.PacketIO) error {
+	for {
+		data, err := backendIO.ReadPacket()
+		if err != nil {
+			return err
+		}
+
+		switch data[0] {
+		case mysql.OKHeader:
+			return nil
+		case ShaCommand:
+			switch data[1] {
+			case FastAuthOk:
+			case FastAuthFail:
+				if err = auth.writeAuthPacket(backendIO, auth.authData, true); err != nil {
+					return err
+				}
+			default:
+				return errors.New(fmt.Sprintf("do not support sha command %d now", data[1]))
+			}
+		case mysql.AuthSwitchRequest:
+			pluginEndIndex := bytes.IndexByte(data, 0x00)
+			plugin := string(data[1:pluginEndIndex])
+			salt := data[pluginEndIndex+1:]
+			authData := passwd.CalculatePassword(salt, auth.authData, plugin)
+			if err = auth.writeAuthPacket(backendIO, authData, false); err != nil {
+				return err
+			}
+		default: // mysql.ErrHeader
+			return errors.New("read auth result error")
+		}
+	}
+}
+
+func (auth *Authenticator) writeAuthPacket(backendIO *pnet.PacketIO, password []byte, addNul bool) error {
+	pktLen := len(password)
+	if addNul {
+		pktLen++
+	}
+
+	data := make([]byte, pktLen)
+	copy(data, password)
+	if addNul {
+		data[pktLen-1] = 0x00
+	}
+	if err := backendIO.WritePacket(data); err != nil {
+		return err
+	}
+	return backendIO.Flush()
 }

--- a/pkg/proxy/sessionmgr/client/client_conn.go
+++ b/pkg/proxy/sessionmgr/client/client_conn.go
@@ -18,7 +18,7 @@ import (
 )
 
 type ClientConnectionImpl struct {
-	tlsConfig    *tls.Config
+	tlsConfig    *tls.Config            // the tls config to connect to clients.
 	pkt          *pnet.PacketIO         // a helper to read and write data in packet format.
 	bufReadConn  *pnet.BufferedReadConn // a buffered-read net.Conn or buffered-read tls.Conn.
 	alloc        arena.Allocator
@@ -102,7 +102,7 @@ func (cc *ClientConnectionImpl) processMsg(ctx context.Context) error {
 }
 
 func (cc *ClientConnectionImpl) Redirect() error {
-	return cc.queryCtx.Redirect(cc.tlsConfig)
+	return cc.queryCtx.Redirect()
 }
 
 func (cc *ClientConnectionImpl) Close() error {

--- a/pkg/util/passwd/passwd.go
+++ b/pkg/util/passwd/passwd.go
@@ -1,9 +1,25 @@
 package passwd
 
-import "crypto/sha1"
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+
+	"github.com/pingcap/tidb/parser/mysql"
+)
 
 // calculatePassword calculate password hash
-func CalculatePassword(scramble, password []byte) []byte {
+func CalculatePassword(scramble, password []byte, authPlugin string) []byte {
+	var authData []byte
+	switch authPlugin {
+	case mysql.AuthNativePassword:
+		authData = CalcNativePassword(scramble, password)
+	case mysql.AuthCachingSha2Password:
+		authData = CalcCachingSha2Password(scramble, password)
+	}
+	return authData
+}
+
+func CalcNativePassword(scramble, password []byte) []byte {
 	if len(password) == 0 {
 		return nil
 	}
@@ -30,4 +46,32 @@ func CalculatePassword(scramble, password []byte) []byte {
 		scramble[i] ^= stage1[i]
 	}
 	return scramble
+}
+
+// CalcCachingSha2Password: Hash password using MySQL 8+ method (SHA256)
+func CalcCachingSha2Password(scramble, password []byte) []byte {
+	if len(password) == 0 {
+		return nil
+	}
+
+	// XOR(SHA256(password), SHA256(SHA256(SHA256(password)), scramble))
+
+	crypt := sha256.New()
+	crypt.Write(password)
+	stage1 := crypt.Sum(nil)
+
+	crypt.Reset()
+	crypt.Write(stage1)
+	hash := crypt.Sum(nil)
+
+	crypt.Reset()
+	crypt.Write(hash)
+	crypt.Write(scramble)
+	message2 := crypt.Sum(nil)
+
+	for i := range stage1 {
+		stage1[i] ^= message2[i]
+	}
+
+	return stage1
 }


### PR DESCRIPTION
Now the proxy supports reconnecting to the server by using the saved user information. However, it only supports caching_sha2_password now.

Test:

Turn on the TLS on TiDB and create a user with caching_sha2_password.

Start a MySQL client connection and check the connection id:
```
mysql -h127.1 -uu1 -P6000 -p123456
mysql> select connection_id();
+-----------------+
| connection_id() |
+-----------------+
|             433 |
+-----------------+
1 row in set (0.00 sec)
```

Send a POST command to the HTTP API:
```
curl -X POST http://127.0.0.1:6001/test/redirect
```

Check the connection id again, the connection id is changed:
```
mysql> select connection_id();
+-----------------+
| connection_id() |
+-----------------+
|             435 |
+-----------------+
1 row in set (0.00 sec)
```

Check the processlist and there's only one connection:
```
mysql> show processlist;
+------+------+-----------------+------+---------+------+------------+------------------+
| Id   | User | Host            | db   | Command | Time | State      | Info             |
+------+------+-----------------+------+---------+------+------------+------------------+
|  435 | u1   | 127.0.0.1:52546 | NULL | Query   |    0 | autocommit | show processlist |
+------+------+-----------------+------+---------+------+------------+------------------+
1 row in set (0.00 sec)
```
