### PR TITLE
backend: support `com_change_user` and multiple statements

### DIFF
--- a/pkg/proxy/net/protocol.go
+++ b/pkg/proxy/net/protocol.go
@@ -1,5 +1,7 @@
 package net
 
+import "bytes"
+
 func ParseLengthEncodedInt(b []byte) (num uint64, isNull bool, n int) {
 	switch b[0] {
 	// 251: NULL
@@ -36,6 +38,14 @@ func ParseLengthEncodedInt(b []byte) (num uint64, isNull bool, n int) {
 	num = uint64(b[0])
 	n = 1
 	return
+}
+
+func ParseNullTermString(b []byte) (str []byte, remain []byte) {
+	off := bytes.IndexByte(b, 0)
+	if off == -1 {
+		return nil, b
+	}
+	return b[:off], b[off+1:]
 }
 
 var tinyIntCache [251][]byte

--- a/pkg/proxy/sessionmgr/backend/authenticator.go
+++ b/pkg/proxy/sessionmgr/backend/authenticator.go
@@ -404,3 +404,13 @@ func (auth *Authenticator) handleSecondAuthResult(backendIO *pnet.PacketIO) erro
 		return errors.Errorf("read unexpected command: %#x", data[0])
 	}
 }
+
+func (auth *Authenticator) changeUser(request []byte) {
+	user, data := pnet.ParseNullTermString(request)
+	auth.user = string(hack.String(user))
+	passLen := int(data[0])
+	data = data[passLen+1:]
+	dbName, _ := pnet.ParseNullTermString(data)
+	auth.dbname = string(hack.String(dbName))
+	// TODO: attrs
+}


### PR DESCRIPTION
This PR supports:
- `COM_CHANGE_USER`, and the proxy will reconnect to the server with the new user name passed in the `COM_CHANGE_USER` command. Unfortunately, there's no way to manually test.
- Multiple statements. Example:

```sql
mysql -h127.1 -uroot -P6000 --delimiter=!
mysql> use test
Database changed
mysql> create table t(id int);!
Query OK, 0 rows affected (0.01 sec)

mysql> select * from t!
Empty set (0.01 sec)

mysql> select * from t;select * from t1;select * from t;!
Empty set (0.00 sec)

ERROR 1146 (42S02): Table 'test.t1' doesn't exist
mysql> begin;select connection_id();insert t values(1);!
Query OK, 0 rows affected (0.00 sec)

+------------------------------------+
| connection_id();insert t values(1) |
+------------------------------------+
|                                403 |
+------------------------------------+
1 row in set (0.00 sec)

Query OK, 1 row affected (0.00 sec)

# redirect here

mysql> select connection_id();select * from t;!
+---------------------------------+
| connection_id();select * from t |
+---------------------------------+
|                             403 |
+---------------------------------+
1 row in set (0.00 sec)

+------+
| id   |
+------+
|    1 |
+------+
1 row in set (0.00 sec)

mysql> rollback;select * from t;!
Query OK, 0 rows affected (0.00 sec)

Empty set (0.00 sec)

mysql> select connection_id()!
+-----------------+
| connection_id() |
+-----------------+
|             405 |
+-----------------+
1 row in set (0.00 sec)
```