### PR TITLE
router: enable router to manage backend connections directly

### DIFF
--- a/pkg/proxy/api.go
+++ b/pkg/proxy/api.go
@@ -90,7 +90,7 @@ func CreateHttpApiServer(proxyServer *server.Server, nsmgr *namespace.NamespaceM
 	pprofRouteGroup.Any("/allocs", gin.WrapF(pprof.Handler("allocs").ServeHTTP))
 
 	testRouteGroup := engine.Group("/test")
-	testHttpHandler := &TestHttpHandler{proxyServer: proxyServer}
+	testHttpHandler := &TestHttpHandler{nsmgr: apiServer.nsmgr}
 	testRouteGroup.POST("/redirect", testHttpHandler.Redirect)
 
 	apiServer.engine = engine
@@ -208,11 +208,11 @@ func CreateSuccessJsonResp() CommonJsonResp {
 }
 
 type TestHttpHandler struct {
-	proxyServer *server.Server
+	nsmgr *namespace.NamespaceManager
 }
 
 func (t *TestHttpHandler) Redirect(c *gin.Context) {
-	err := t.proxyServer.RedirectConnections()
+	err := t.nsmgr.RedirectConnections()
 	if err != nil {
 		errMsg := "redirect connections error"
 		logutil.BgLogger().Error(errMsg, zap.Error(err))

--- a/pkg/proxy/driver/driver.go
+++ b/pkg/proxy/driver/driver.go
@@ -6,7 +6,7 @@ import (
 )
 
 type createClientConnFunc func(QueryCtx, net.Conn, uint64, *tls.Config, *tls.Config) ClientConnection
-type createBackendConnMgrFunc func() BackendConnManager
+type createBackendConnMgrFunc func(connectionID uint64) BackendConnManager
 
 type DriverImpl struct {
 	nsmgr                    NamespaceManager
@@ -23,7 +23,7 @@ func NewDriverImpl(nsmgr NamespaceManager, createClientConnFunc createClientConn
 }
 
 func (d *DriverImpl) CreateClientConnection(conn net.Conn, connectionID uint64, serverTLSConfig, clusterTLSConfig *tls.Config) ClientConnection {
-	backendConnMgr := d.createBackendConnMgrFunc()
+	backendConnMgr := d.createBackendConnMgrFunc(connectionID)
 	queryCtx := NewQueryCtxImpl(d.nsmgr, backendConnMgr, connectionID)
 	return d.createClientConnFunc(queryCtx, conn, connectionID, serverTLSConfig, clusterTLSConfig)
 }

--- a/pkg/proxy/driver/queryctx.go
+++ b/pkg/proxy/driver/queryctx.go
@@ -62,24 +62,15 @@ func (q *QueryCtxImpl) ConnectBackend(ctx context.Context, clientIO *pnet.Packet
 		return errors.New("failed to find a namespace")
 	}
 	q.ns = ns
-	addr, err := ns.GetRouter().Route()
+	router := ns.GetRouter()
+	addr, err := router.Route()
 	if err != nil {
 		return err
 	}
+	q.connMgr.SetEventReceiver(router)
 	if err = q.connMgr.Connect(ctx, addr, clientIO, serverTLSConfig, backendTLSConfig); err != nil {
 		return err
 	}
 	q.ns.IncrConnCount()
-	return nil
-}
-
-func (q *QueryCtxImpl) Redirect() error {
-	addr, err := q.ns.GetRouter().Route()
-	if err != nil {
-		return err
-	}
-	if err = q.connMgr.Redirect(addr); err != nil {
-		return err
-	}
 	return nil
 }

--- a/pkg/proxy/namespace/namespace.go
+++ b/pkg/proxy/namespace/namespace.go
@@ -20,11 +20,11 @@ type NamespaceWrapper struct {
 	connCounter int64
 }
 
-func CreateNamespaceHolder(cfgs []*config.Namespace, build NamespaceBuilder) (*NamespaceHolder, error) {
+func CreateNamespaceHolder(cfgs []*config.Namespace) (*NamespaceHolder, error) {
 	nss := make(map[string]Namespace, len(cfgs))
 
 	for _, cfg := range cfgs {
-		ns, err := build(cfg)
+		ns, err := BuildNamespace(cfg)
 		if err != nil {
 			return nil, errors.WithMessage(err, fmt.Sprintf("create namespace error, namespace: %s", cfg.Namespace))
 		}
@@ -58,6 +58,17 @@ func (n *NamespaceHolder) Clone() *NamespaceHolder {
 	return &NamespaceHolder{
 		nss: nss,
 	}
+}
+
+func (n *NamespaceHolder) RedirectConnections() error {
+	var err error
+	for _, ns := range n.nss {
+		err1 := ns.GetRouter().RedirectConnections()
+		if err == nil && err1 != nil {
+			err = err1
+		}
+	}
+	return err
 }
 
 func (n *NamespaceWrapper) Name() string {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -53,7 +53,7 @@ func (p *Proxy) Init() error {
 	if err != nil {
 		return err
 	}
-	nsmgr, err := namespace.CreateNamespaceManager(nss, namespace.BuildNamespace, namespace.DefaultAsyncCloseNamespace)
+	nsmgr, err := namespace.CreateNamespaceManager(nss)
 	if err != nil {
 		return err
 	}

--- a/pkg/proxy/router/backend_observer.go
+++ b/pkg/proxy/router/backend_observer.go
@@ -192,7 +192,7 @@ func (bo *BackendObserver) fetchBackendList(ctx context.Context) (map[string]*Ba
 				zap.ByteString("value", kv.Value), zap.Error(err))
 			return nil, err
 		}
-		addr := key[len(infosync.TopologyInformationPath)+1 : len(key)-len("info")]
+		addr := key[len(infosync.TopologyInformationPath)+1 : len(key)-len("/info")]
 		backendInfo[addr] = &BackendInfo{
 			TopologyInfo: topo,
 			status:       StatusHealthy,
@@ -246,7 +246,7 @@ func (bo *BackendObserver) notifyIfChanged(backendInfo map[string]*BackendInfo) 
 		if newInfo.status == StatusHealthy {
 			originalInfo, ok := bo.backendInfo[addr]
 			if !ok || originalInfo.status != StatusHealthy {
-				addedBackends[addr] = originalInfo
+				addedBackends[addr] = newInfo
 			}
 		}
 	}

--- a/pkg/proxy/router/router.go
+++ b/pkg/proxy/router/router.go
@@ -2,7 +2,8 @@ package router
 
 import (
 	"errors"
-	"math/rand"
+	"math"
+	"sync"
 
 	"github.com/djshow832/weir/pkg/config"
 	"github.com/djshow832/weir/pkg/proxy/driver"
@@ -14,66 +15,198 @@ var (
 	ErrNoInstanceToSelect = errors.New("no instances to route")
 )
 
+type ConnList struct {
+	//sync.Mutex
+	backendInfo *BackendInfo
+	movingIn    map[uint64]driver.RedirectableConn
+	active      map[uint64]driver.RedirectableConn
+	movingOut   map[uint64]driver.RedirectableConn
+}
+
 type RandomRouter struct {
-	observer   *BackendObserver
-	addresses  []string
-	addr2Conns map[string]int
+	observer *BackendObserver
+	mu       struct {
+		sync.Mutex
+		conns map[string]*ConnList
+	}
 }
 
 func NewRandomRouter(cfg *config.BackendNamespace) (*RandomRouter, error) {
-	router := &RandomRouter{
-		addr2Conns: make(map[string]int, 0),
-	}
+	router := &RandomRouter{}
 	observer, err := NewBackendObserver(router.onBackendChanged)
 	if err != nil {
 		return nil, err
 	}
 	router.observer = observer
-	if observer == nil {
-		if len(cfg.Instances) == 0 {
-			return nil, ErrNoInstanceToSelect
+	err = router.initConnections(cfg.Instances)
+	return router, err
+}
+
+func (router *RandomRouter) initConnections(addrs []string) error {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	router.mu.conns = make(map[string]*ConnList)
+	if router.observer == nil {
+		if len(addrs) == 0 {
+			return ErrNoInstanceToSelect
 		}
-		router.SetAddresses(cfg.Instances)
+		for _, addr := range addrs {
+			router.mu.conns[addr] = &ConnList{
+				backendInfo: &BackendInfo{
+					status: StatusHealthy,
+				},
+				movingIn:  make(map[uint64]driver.RedirectableConn),
+				active:    make(map[uint64]driver.RedirectableConn),
+				movingOut: make(map[uint64]driver.RedirectableConn),
+			}
+		}
 	}
-	return router, nil
-}
-
-func (router *RandomRouter) SetAddresses(addresses []string) {
-	router.addresses = addresses
-	for _, addr := range addresses {
-		router.addr2Conns[addr] = 0
-	}
-}
-
-func (router *RandomRouter) Route() (string, error) {
-	length := len(router.addr2Conns)
-	switch length {
-	case 0:
-		return "", ErrNoInstanceToSelect
-	case 1:
-		return router.addresses[0], nil
-	default:
-		return router.addresses[rand.Intn(length)], nil
-	}
-}
-
-func (router *RandomRouter) AddConnOnAddr(addr string, num int) {
-	router.addr2Conns[addr] += num
-}
-
-func (router *RandomRouter) updateBackend(addr2Conn map[string]driver.ClientConnection, addresses []string) error {
 	return nil
 }
 
+func (router *RandomRouter) Route() (string, error) {
+	leastConnNum := math.MaxInt
+	var leastConnAddr string
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	for addr, connList := range router.mu.conns {
+		if connList.backendInfo.status == StatusHealthy {
+			num := len(connList.movingIn) + len(connList.active)
+			if num < leastConnNum {
+				leastConnNum = num
+				leastConnAddr = addr
+			}
+		}
+	}
+	if len(leastConnAddr) == 0 {
+		return leastConnAddr, ErrNoInstanceToSelect
+	}
+	return leastConnAddr, nil
+}
+
+// ConnCount returns the overall connections on backend servers.
+// The result may be inaccurate during connection migration.
+func (router *RandomRouter) ConnCount() int {
+	connNum := 0
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	for _, connList := range router.mu.conns {
+		connNum += len(connList.active) + len(connList.movingOut)
+	}
+	return connNum
+}
+
+func (router *RandomRouter) AddConn(addr string, conn driver.RedirectableConn) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	conns, ok := router.mu.conns[addr]
+	if !ok {
+		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
+	}
+	// TODO: check health
+	conns.active[conn.ConnectionID()] = conn
+}
+
+func (router *RandomRouter) RedirectConnections() error {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	var err error
+	for addr, connList := range router.mu.conns {
+		for _, conn := range connList.active {
+			err1 := conn.Redirect(addr)
+			if err == nil && err1 != nil {
+				err = err1
+			}
+		}
+	}
+	return err
+}
+
+func (router *RandomRouter) BeginRedirect(from, to string, conn driver.RedirectableConn) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	originalConns, ok := router.mu.conns[from]
+	if !ok {
+		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", from))
+		return
+	}
+	connID := conn.ConnectionID()
+	if _, ok = originalConns.movingOut[connID]; ok {
+		return
+	}
+	delete(originalConns.active, connID)
+	delete(originalConns.movingIn, connID)
+	originalConns.movingOut[connID] = conn
+
+	newConns, ok := router.mu.conns[to]
+	if !ok {
+		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
+		return
+	}
+	newConns.movingIn[connID] = conn
+}
+
+func (router *RandomRouter) FinishRedirect(from, to string, conn driver.RedirectableConn) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	originalConns, ok := router.mu.conns[from]
+	if !ok {
+		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", from))
+		return
+	}
+	connID := conn.ConnectionID()
+	delete(originalConns.movingOut, connID)
+	newConns, ok := router.mu.conns[to]
+	if !ok {
+		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
+		return
+	}
+	delete(newConns.movingIn, connID)
+	newConns.active[connID] = conn
+}
+
+func (router *RandomRouter) CloseConn(addr string, conn driver.RedirectableConn) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	originalConns, ok := router.mu.conns[addr]
+	if !ok {
+		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
+		return
+	}
+	connID := conn.ConnectionID()
+	delete(originalConns.active, connID)
+}
+
 func (router *RandomRouter) onBackendChanged(removed, added map[string]*BackendInfo) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
 	for addr, info := range removed {
 		logutil.BgLogger().Info("remove backend", zap.String("url", addr), zap.String("status", info.status.String()))
+		conns, ok := router.mu.conns[addr]
+		if !ok {
+			logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
+			continue
+		}
+		conns.backendInfo = info
 	}
-	for addr := range added {
+	for addr, info := range added {
 		logutil.BgLogger().Info("add backend", zap.String("url", addr))
+		conns, ok := router.mu.conns[addr]
+		if !ok {
+			router.mu.conns[addr] = &ConnList{
+				backendInfo: info,
+				movingIn:    make(map[uint64]driver.RedirectableConn),
+				active:      make(map[uint64]driver.RedirectableConn),
+				movingOut:   make(map[uint64]driver.RedirectableConn),
+			}
+		} else {
+			conns.backendInfo = info
+		}
 	}
+	// TODO: rebalance
 }
 
 func (router *RandomRouter) Close() {
 	router.observer.Close()
+	// Router only refers to RedirectableConn, it doesn't manage RedirectableConn.
 }

--- a/pkg/proxy/server/server.go
+++ b/pkg/proxy/server/server.go
@@ -225,6 +225,10 @@ func (s *Server) Close() {
 		terror.Log(errors.Trace(err))
 		s.listener = nil
 	}
+	for _, conn := range s.clients {
+		err := conn.Close()
+		terror.Log(errors.Trace(err))
+	}
 	metrics.ServerEventCounter.WithLabelValues(metrics.EventClose).Inc()
 }
 
@@ -236,16 +240,4 @@ func (s *Server) TryGracefulDown() {
 // GracefulDown waits all clients to close.
 func (s *Server) GracefulDown(ctx context.Context, done chan struct{}) {
 	return
-}
-
-func (s *Server) RedirectConnections() error {
-	s.rwlock.RLock()
-	defer s.rwlock.RUnlock()
-	for _, conn := range s.clients {
-		err := conn.Redirect()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/proxy/sessionmgr/backend/backend_conn.go
+++ b/pkg/proxy/sessionmgr/backend/backend_conn.go
@@ -16,6 +16,7 @@ const (
 type connectionPhase byte
 
 type BackendConnection interface {
+	Addr() string
 	Connect() error
 	PacketIO() *pnet.PacketIO
 	Close() error
@@ -34,6 +35,10 @@ func NewBackendConnectionImpl(address string) *BackendConnectionImpl {
 		address: address,
 		alloc:   arena.NewAllocator(32 * 1024),
 	}
+}
+
+func (bc *BackendConnectionImpl) Addr() string {
+	return bc.address
 }
 
 func (bc *BackendConnectionImpl) Connect() error {

--- a/pkg/proxy/sessionmgr/client/client_conn.go
+++ b/pkg/proxy/sessionmgr/client/client_conn.go
@@ -85,10 +85,6 @@ func (cc *ClientConnectionImpl) processMsg(ctx context.Context) error {
 	}
 }
 
-func (cc *ClientConnectionImpl) Redirect() error {
-	return cc.queryCtx.Redirect()
-}
-
 func (cc *ClientConnectionImpl) Close() error {
 	if err := cc.pkt.Close(); err != nil {
 		terror.Log(err)


### PR DESCRIPTION
Previously, the router could not see connections. Now the router has 3 queues for each backend server:
- movingIn
- active
- movingOut

The previous caller link is:
- `Server` -> `ClientConnection` -> `QueryCtx` -> `Router` / `BackendConnMgr`.

The current caller link is:
- `NamespaceManager` -> `NamespaceHolder` -> `NamespaceImpl` -> `Router` -> `BackendConnMgr`.

So that the router can manage connections alone and doesn't rely on the `QueryCtx` anymore. And the `BackendConnMgr` can notify the router directly when it's connected, redirected, or closed.

These changes prepare the rebalance algorithm for future pull requests.