### PR TITLE
router: migrate connection automatically during scale-in and scale-out

### DIFF
--- a/pkg/proxy/driver/domain.go
+++ b/pkg/proxy/driver/domain.go
@@ -51,15 +51,16 @@ type Router interface {
 
 type RedirectableConn interface {
 	SetEventReceiver(receiver ConnEventReceiver)
-	Redirect(addr string) error
+	Redirect(addr string)
 	ConnectionID() uint64
 }
 
 type ConnEventReceiver interface {
-	AddConn(addr string, conn RedirectableConn)
-	BeginRedirect(from, to string, conn RedirectableConn)
-	FinishRedirect(from, to string, conn RedirectableConn)
-	CloseConn(addr string, conn RedirectableConn)
+	OnConnCreated(addr string, conn RedirectableConn)
+	OnRedirectBegin(from, to string, conn RedirectableConn)
+	OnRedirectSucceed(from, to string, conn RedirectableConn)
+	OnRedirectFail(from, to string, conn RedirectableConn)
+	OnConnClosed(addr string, conn RedirectableConn)
 }
 
 type Stmt interface {

--- a/pkg/proxy/router/router.go
+++ b/pkg/proxy/router/router.go
@@ -1,9 +1,12 @@
 package router
 
 import (
+	"container/list"
+	"context"
 	"errors"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/djshow832/weir/pkg/config"
 	"github.com/djshow832/weir/pkg/proxy/driver"
@@ -15,49 +18,75 @@ var (
 	ErrNoInstanceToSelect = errors.New("no instances to route")
 )
 
-type ConnList struct {
-	//sync.Mutex
-	backendInfo *BackendInfo
-	movingIn    map[uint64]driver.RedirectableConn
-	active      map[uint64]driver.RedirectableConn
-	movingOut   map[uint64]driver.RedirectableConn
+const (
+	phaseNotRedirected int = iota
+	phaseRedirectNotify
+	phaseRedirectBegin
+	phaseRedirectEnd
+	phaseRedirectFail
+)
+
+const (
+	rebalanceInterval     = 10 * time.Millisecond
+	rebalanceConnsPerLoop = 10
+	rebalancePctThreshold = 0.1
+)
+
+type BackendWrapper struct {
+	BackendInfo
+	connList *list.List
+	connMap  map[uint64]*list.Element
+}
+
+type ConnWrapper struct {
+	driver.RedirectableConn
+	phase int
+}
+
+type RedirectRequest struct {
+	from   string
+	connID uint64
 }
 
 type RandomRouter struct {
-	observer *BackendObserver
-	mu       struct {
+	observer   *BackendObserver
+	cancelFunc context.CancelFunc
+	mu         struct {
 		sync.Mutex
-		conns map[string]*ConnList
+		backends map[string]*BackendWrapper
 	}
 }
 
 func NewRandomRouter(cfg *config.BackendNamespace) (*RandomRouter, error) {
 	router := &RandomRouter{}
-	observer, err := NewBackendObserver(router.onBackendChanged)
+	observer, err := NewBackendObserver(router)
 	if err != nil {
 		return nil, err
 	}
 	router.observer = observer
 	err = router.initConnections(cfg.Instances)
+	childCtx, cancelFunc := context.WithCancel(context.Background())
+	go router.rebalanceLoop(childCtx)
+	router.cancelFunc = cancelFunc
 	return router, err
 }
 
 func (router *RandomRouter) initConnections(addrs []string) error {
 	router.mu.Lock()
 	defer router.mu.Unlock()
-	router.mu.conns = make(map[string]*ConnList)
+	router.mu.backends = make(map[string]*BackendWrapper)
 	if router.observer == nil {
+		logutil.BgLogger().Info("pd addr is not configured, use static backend instances instead.")
 		if len(addrs) == 0 {
 			return ErrNoInstanceToSelect
 		}
 		for _, addr := range addrs {
-			router.mu.conns[addr] = &ConnList{
-				backendInfo: &BackendInfo{
+			router.mu.backends[addr] = &BackendWrapper{
+				BackendInfo: BackendInfo{
 					status: StatusHealthy,
 				},
-				movingIn:  make(map[uint64]driver.RedirectableConn),
-				active:    make(map[uint64]driver.RedirectableConn),
-				movingOut: make(map[uint64]driver.RedirectableConn),
+				connList: list.New(),
+				connMap:  make(map[uint64]*list.Element),
 			}
 		}
 	}
@@ -69,9 +98,9 @@ func (router *RandomRouter) Route() (string, error) {
 	var leastConnAddr string
 	router.mu.Lock()
 	defer router.mu.Unlock()
-	for addr, connList := range router.mu.conns {
-		if connList.backendInfo.status == StatusHealthy {
-			num := len(connList.movingIn) + len(connList.active)
+	for addr, backend := range router.mu.backends {
+		if backend.status == StatusHealthy {
+			num := len(backend.connMap)
 			if num < leastConnNum {
 				leastConnNum = num
 				leastConnAddr = addr
@@ -90,123 +119,324 @@ func (router *RandomRouter) ConnCount() int {
 	connNum := 0
 	router.mu.Lock()
 	defer router.mu.Unlock()
-	for _, connList := range router.mu.conns {
-		connNum += len(connList.active) + len(connList.movingOut)
+	for _, backend := range router.mu.backends {
+		connNum += len(backend.connMap)
 	}
 	return connNum
 }
 
-func (router *RandomRouter) AddConn(addr string, conn driver.RedirectableConn) {
+func (router *RandomRouter) OnConnCreated(addr string, conn driver.RedirectableConn) {
 	router.mu.Lock()
 	defer router.mu.Unlock()
-	conns, ok := router.mu.conns[addr]
+	backend, ok := router.mu.backends[addr]
 	if !ok {
+		// The backend may be just down and moved away.
 		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
+		return
 	}
-	// TODO: check health
-	conns.active[conn.ConnectionID()] = conn
+	connWrapper := &ConnWrapper{
+		RedirectableConn: conn,
+		phase:            phaseNotRedirected,
+	}
+	e := backend.connList.PushBack(connWrapper)
+	backend.connMap[conn.ConnectionID()] = e
 }
 
 func (router *RandomRouter) RedirectConnections() error {
+	requests := make([]*RedirectRequest, 0)
 	router.mu.Lock()
-	defer router.mu.Unlock()
-	var err error
-	for addr, connList := range router.mu.conns {
-		for _, conn := range connList.active {
-			err1 := conn.Redirect(addr)
-			if err == nil && err1 != nil {
-				err = err1
-			}
+	for addr, backend := range router.mu.backends {
+		for e := backend.connList.Front(); e != nil; e = e.Next() {
+			requests = append(requests, &RedirectRequest{
+				from:   addr,
+				connID: e.Value.(*ConnWrapper).ConnectionID(),
+			})
 		}
 	}
-	return err
+	router.mu.Unlock()
+	for _, request := range requests {
+		to, err := router.Route()
+		if err != nil {
+			logutil.BgLogger().Warn("redirecting encounters an error", zap.Error(err))
+			break
+		}
+		// This is only for test, so we allow it to reconnect to the same backend.
+		router.notifyRedirect(request.from, to, request.connID)
+	}
+	return nil
 }
 
-func (router *RandomRouter) BeginRedirect(from, to string, conn driver.RedirectableConn) {
+func (router *RandomRouter) notifyRedirect(from, to string, connID uint64) {
 	router.mu.Lock()
 	defer router.mu.Unlock()
-	originalConns, ok := router.mu.conns[from]
+	originalBackend, ok := router.mu.backends[from]
 	if !ok {
 		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", from))
 		return
 	}
-	connID := conn.ConnectionID()
-	if _, ok = originalConns.movingOut[connID]; ok {
-		return
-	}
-	delete(originalConns.active, connID)
-	delete(originalConns.movingIn, connID)
-	originalConns.movingOut[connID] = conn
-
-	newConns, ok := router.mu.conns[to]
+	newBackend, ok := router.mu.backends[to]
 	if !ok {
 		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
 		return
 	}
-	newConns.movingIn[connID] = conn
-}
-
-func (router *RandomRouter) FinishRedirect(from, to string, conn driver.RedirectableConn) {
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	originalConns, ok := router.mu.conns[from]
+	e, ok := originalBackend.connMap[connID]
 	if !ok {
-		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", from))
+		// It may have been redirected or closed. It's fine, we can redirect it at next time if necessary.
 		return
 	}
+	if newBackend.status != StatusHealthy {
+		return
+	}
+	connWrapper := e.Value.(*ConnWrapper)
+	switch connWrapper.phase {
+	// We do not send concurrent signals.
+	case phaseRedirectNotify, phaseRedirectBegin:
+		return
+	}
+	originalBackend.connList.Remove(e)
+	delete(originalBackend.connMap, connID)
+	router.removeBackendIfEmpty(from, originalBackend)
+	connWrapper.phase = phaseRedirectNotify
+	e = newBackend.connList.PushBack(connWrapper)
+	newBackend.connMap[connID] = e
+	connWrapper.Redirect(to)
+}
+
+func (router *RandomRouter) OnRedirectBegin(from, to string, conn driver.RedirectableConn) {
 	connID := conn.ConnectionID()
-	delete(originalConns.movingOut, connID)
-	newConns, ok := router.mu.conns[to]
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	newBackend, ok := router.mu.backends[to]
 	if !ok {
 		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
 		return
 	}
-	delete(newConns.movingIn, connID)
-	newConns.active[connID] = conn
+	e, ok := newBackend.connMap[connID]
+	if !ok {
+		// Impossible here.
+		return
+	}
+	connWrapper := e.Value.(*ConnWrapper)
+	if connWrapper.phase != phaseRedirectNotify {
+		// Impossible here.
+		return
+	}
+	connWrapper.phase = phaseRedirectBegin
 }
 
-func (router *RandomRouter) CloseConn(addr string, conn driver.RedirectableConn) {
+func (router *RandomRouter) OnRedirectSucceed(from, to string, conn driver.RedirectableConn) {
+	connID := conn.ConnectionID()
 	router.mu.Lock()
 	defer router.mu.Unlock()
-	originalConns, ok := router.mu.conns[addr]
+	newBackend, ok := router.mu.backends[to]
+	if !ok {
+		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
+		return
+	}
+	e, ok := newBackend.connMap[connID]
+	if !ok {
+		// Impossible here.
+		return
+	}
+	connWrapper := e.Value.(*ConnWrapper)
+	if connWrapper.phase != phaseRedirectBegin {
+		// Impossible here.
+		return
+	}
+	connWrapper.phase = phaseRedirectEnd
+}
+
+func (router *RandomRouter) OnRedirectFail(from, to string, conn driver.RedirectableConn) {
+	connID := conn.ConnectionID()
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	newBackend, ok := router.mu.backends[to]
+	if !ok {
+		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
+		return
+	}
+	e, ok := newBackend.connMap[connID]
+	if !ok {
+		// Impossible here.
+		return
+	}
+	connWrapper := e.Value.(*ConnWrapper)
+	if connWrapper.phase != phaseRedirectBegin {
+		// Impossible here.
+		return
+	}
+	connWrapper.phase = phaseRedirectFail
+	newBackend.connList.Remove(e)
+	delete(newBackend.connMap, connID)
+	originalBackend, ok := router.mu.backends[from]
+	if !ok {
+		// The backend may be removed already, then the connection is discarded from the router.
+		return
+	}
+	e = originalBackend.connList.PushBack(connWrapper)
+	originalBackend.connMap[connID] = e
+}
+
+func (router *RandomRouter) OnConnClosed(addr string, conn driver.RedirectableConn) {
+	connID := conn.ConnectionID()
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	backend, ok := router.mu.backends[addr]
 	if !ok {
 		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
 		return
 	}
-	connID := conn.ConnectionID()
-	delete(originalConns.active, connID)
+	e, ok := backend.connMap[connID]
+	if !ok {
+		// Impossible here.
+		return
+	}
+	backend.connList.Remove(e)
+	delete(backend.connMap, connID)
+	router.removeBackendIfEmpty(addr, backend)
 }
 
-func (router *RandomRouter) onBackendChanged(removed, added map[string]*BackendInfo) {
+func (router *RandomRouter) OnBackendChanged(removed, added map[string]*BackendInfo) {
 	router.mu.Lock()
 	defer router.mu.Unlock()
 	for addr, info := range removed {
 		logutil.BgLogger().Info("remove backend", zap.String("url", addr), zap.String("status", info.status.String()))
-		conns, ok := router.mu.conns[addr]
+		backend, ok := router.mu.backends[addr]
 		if !ok {
 			logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
 			continue
 		}
-		conns.backendInfo = info
+		backend.BackendInfo = *info
+		router.removeBackendIfEmpty(addr, backend)
 	}
 	for addr, info := range added {
 		logutil.BgLogger().Info("add backend", zap.String("url", addr))
-		conns, ok := router.mu.conns[addr]
+		backend, ok := router.mu.backends[addr]
 		if !ok {
-			router.mu.conns[addr] = &ConnList{
-				backendInfo: info,
-				movingIn:    make(map[uint64]driver.RedirectableConn),
-				active:      make(map[uint64]driver.RedirectableConn),
-				movingOut:   make(map[uint64]driver.RedirectableConn),
+			router.mu.backends[addr] = &BackendWrapper{
+				BackendInfo: *info,
+				connList:    list.New(),
+				connMap:     make(map[uint64]*list.Element),
 			}
 		} else {
-			conns.backendInfo = info
+			backend.BackendInfo = *info
 		}
 	}
-	// TODO: rebalance
+}
+
+func (router *RandomRouter) rebalanceLoop(ctx context.Context) {
+	for {
+		requests := router.getStrayConns(rebalanceConnsPerLoop)
+		// If there are any homeless connections this loop, we move unbalanced connections
+		// in the next loop to simplify the logic.
+		if len(requests) == 0 {
+			requests = router.getUnbalancedConns(rebalanceConnsPerLoop)
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		if len(requests) > 0 {
+			router.redirectConns(requests)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(rebalanceInterval):
+		}
+	}
+}
+
+func (router *RandomRouter) getStrayConns(maxNum int) []*RedirectRequest {
+	requests := make([]*RedirectRequest, 0, maxNum)
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	for addr, backend := range router.mu.backends {
+		if backend.status != StatusHealthy {
+			for e := backend.connList.Front(); e != nil && len(requests) < maxNum; e = e.Next() {
+				id := e.Value.(*ConnWrapper).ConnectionID()
+				requests = append(requests, &RedirectRequest{
+					from:   addr,
+					connID: id,
+				})
+			}
+		}
+		if len(requests) >= maxNum {
+			break
+		}
+	}
+	return requests
+}
+
+func (router *RandomRouter) getUnbalancedConns(maxNum int) []*RedirectRequest {
+	var (
+		totalConns, totalBackends, maxConnNum int
+		maxConnAddr                           string
+	)
+	requests := make([]*RedirectRequest, 0, maxNum)
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	for addr, backend := range router.mu.backends {
+		if backend.status == StatusHealthy {
+			totalBackends++
+			connNum := len(backend.connMap)
+			totalConns += connNum
+			if connNum > maxConnNum {
+				maxConnNum = connNum
+				maxConnAddr = addr
+			}
+		}
+	}
+	if totalBackends <= 1 || totalConns <= 1 {
+		return requests
+	}
+	avgConnNum := float64(totalConns) / float64(totalBackends)
+	threshold := int(avgConnNum*(1+rebalancePctThreshold)) + 1
+	// We only rebalance one overloaded backend at one time.
+	if maxConnNum > threshold {
+		if maxConnNum-threshold < maxNum {
+			maxNum = maxConnNum - threshold
+		}
+		backend := router.mu.backends[maxConnAddr]
+		for e := backend.connList.Front(); e != nil && len(requests) < maxNum; e = e.Next() {
+			id := e.Value.(*ConnWrapper).ConnectionID()
+			requests = append(requests, &RedirectRequest{
+				from:   maxConnAddr,
+				connID: id,
+			})
+		}
+	}
+	return requests
+}
+
+func (router *RandomRouter) redirectConns(requests []*RedirectRequest) {
+	for _, request := range requests {
+		to, err := router.Route()
+		if err != nil {
+			// All instances are down. We don't log here because the logs will be too many.
+			break
+		}
+		if request.from == to {
+			continue
+		}
+		router.notifyRedirect(request.from, to, request.connID)
+	}
+}
+
+func (router *RandomRouter) removeBackendIfEmpty(addr string, backend *BackendWrapper) {
+	if (backend.status == StatusServerDown || backend.status == StatusCannotConnect) && backend.connList.Len() == 0 {
+		delete(router.mu.backends, addr)
+	}
 }
 
 func (router *RandomRouter) Close() {
-	router.observer.Close()
+	if router.cancelFunc != nil {
+		router.cancelFunc()
+		router.cancelFunc = nil
+	}
+	if router.observer != nil {
+		router.observer.Close()
+		router.observer = nil
+	}
 	// Router only refers to RedirectableConn, it doesn't manage RedirectableConn.
 }

--- a/pkg/proxy/sessionmgr/client/client_conn.go
+++ b/pkg/proxy/sessionmgr/client/client_conn.go
@@ -53,7 +53,6 @@ func (cc *ClientConnectionImpl) Run(ctx context.Context) {
 		terror.Log(errors.Trace(err))
 		return
 	}
-	logutil.Logger(ctx).Info("new connection succeeds", zap.Uint64("connID", cc.connectionID), zap.String("remoteAddr", cc.Addr()))
 
 	if err := cc.processMsg(ctx); err != nil {
 		logutil.Logger(ctx).Info("process message fails", zap.Uint64("connID", cc.connectionID), zap.String("remoteAddr", cc.Addr()), zap.Error(err))


### PR DESCRIPTION
The router now observes the changes of backend servers and connections. It will:
- Move stray connections from inactive nodes to active nodes automatically, which corresponds to scale-in.
- Move connections from overloaded nodes to less loaded nodes, which corresponds to scale-out. If the number of connections on a specific backend server is greater than the average connection number, then the node is treated as overloaded.
- Roll-upgrading is composed of scale-in and scale-out, so it's also supported.

Example:
1. Start a cluster with TiUP. The cluster has 2 TiDB nodes, each of which is built with the latest version of https://github.com/djshow832/tidb: `tiup playground v6.0.0 --tiflash 0 --db 2`
2. Start a sysbench at 19:15:30: `sysbench oltp_point_select --table_size=100000 --mysql-user=root --threads=100 --time=300 --report-interval=10 --mysql-host=127.0.0.1 --mysql-port=6000 --mysql-db=sbtest  run`
3. Scale out the cluster with 1 more TiDB node at 19:18:00: `tiup playground scale-out --db 1`
4. Scale in the cluster  at 19:19:30: `tiup playground scale-in --pid 85728`

The connection counts of TiDB nodes look like this:
![image](https://user-images.githubusercontent.com/29590578/169284996-40c30a5b-4826-493b-acc7-ae68528ee558.png)

Note that the numbers of connections are different at the beginning because the router always chooses the node with the least connections. However, the numbers are both 0 at the beginning until the connections are established (at the same time). I'll optimize it in the next PR.