### PR TITLE
router: make routing more even when there is a sudden flow

### DIFF
--- a/pkg/proxy/driver/domain.go
+++ b/pkg/proxy/driver/domain.go
@@ -44,7 +44,7 @@ type RateLimiter interface {
 
 type Router interface {
 	ConnEventReceiver
-	Route() (string, error)
+	Route(RedirectableConn) (string, error)
 	RedirectConnections() error
 	Close()
 }
@@ -56,8 +56,6 @@ type RedirectableConn interface {
 }
 
 type ConnEventReceiver interface {
-	OnConnCreated(addr string, conn RedirectableConn)
-	OnRedirectBegin(from, to string, conn RedirectableConn)
 	OnRedirectSucceed(from, to string, conn RedirectableConn)
 	OnRedirectFail(from, to string, conn RedirectableConn)
 	OnConnClosed(addr string, conn RedirectableConn)

--- a/pkg/proxy/driver/queryctx.go
+++ b/pkg/proxy/driver/queryctx.go
@@ -63,11 +63,10 @@ func (q *QueryCtxImpl) ConnectBackend(ctx context.Context, clientIO *pnet.Packet
 	}
 	q.ns = ns
 	router := ns.GetRouter()
-	addr, err := router.Route()
+	addr, err := router.Route(q.connMgr)
 	if err != nil {
 		return err
 	}
-	q.connMgr.SetEventReceiver(router)
 	if err = q.connMgr.Connect(ctx, addr, clientIO, serverTLSConfig, backendTLSConfig); err != nil {
 		return err
 	}


### PR DESCRIPTION
In the previous PR https://github.com/djshow832/weir/pull/21, the connections are not even at the beginning, because the `RedirectableConn` without connections are not counted. So when there is a sudden flow, the router always routes to the first backend.

This PR adds `RedirectableConn` to the router as soon as the router routes the connection. So the connections are more even.
At the beginning, there are 2 backends, and the connections are even. I did one scale-out and 2 scale-in after that:

![image](https://user-images.githubusercontent.com/29590578/169442927-2243f5af-528e-4cd4-9b38-28dd05aa9372.png)
