### PR TITLE
router: fix router sometimes doesn't redirect sessions when scale-out

### DIFF
--- a/pkg/proxy/driver/domain.go
+++ b/pkg/proxy/driver/domain.go
@@ -43,7 +43,6 @@ type RateLimiter interface {
 }
 
 type Router interface {
-	ConnEventReceiver
 	Route(RedirectableConn) (string, error)
 	RedirectConnections() error
 	Close()

--- a/pkg/proxy/router/router.go
+++ b/pkg/proxy/router/router.go
@@ -4,7 +4,6 @@ import (
 	"container/list"
 	"context"
 	"errors"
-	"math"
 	"sync"
 	"time"
 
@@ -26,15 +25,21 @@ const (
 )
 
 const (
-	rebalanceInterval     = 10 * time.Millisecond
-	rebalanceConnsPerLoop = 10
-	rebalancePctThreshold = 0.1
+	rebalanceInterval      = 10 * time.Millisecond
+	rebalanceConnsPerLoop  = 10
+	rebalanceMaxScoreRatio = 1.1
 )
 
 type BackendWrapper struct {
 	BackendInfo
+	addr string
+	// A list of *ConnWrapper and is ordered by the connecting or redirecting time.
 	connList *list.List
 	connMap  map[uint64]*list.Element
+}
+
+func (b *BackendWrapper) score() int {
+	return b.status.ToScore() + b.connList.Len()
 }
 
 type ConnWrapper struct {
@@ -42,278 +47,221 @@ type ConnWrapper struct {
 	phase int
 }
 
-type RedirectRequest struct {
-	from   string
-	connID uint64
-}
-
 type RandomRouter struct {
+	sync.Mutex
 	observer   *BackendObserver
 	cancelFunc context.CancelFunc
-	mu         struct {
-		sync.Mutex
-		backends map[string]*BackendWrapper
-	}
+	// A list of *BackendWrapper and ordered by the score of the backends.
+	backends *list.List
 }
 
 func NewRandomRouter(cfg *config.BackendNamespace) (*RandomRouter, error) {
-	router := &RandomRouter{}
-	observer, err := NewBackendObserver(router)
+	router := &RandomRouter{
+		backends: list.New(),
+	}
+	router.Lock()
+	defer router.Unlock()
+	observer, err := NewBackendObserver(router, cfg.Instances)
 	if err != nil {
 		return nil, err
 	}
 	router.observer = observer
-	err = router.initConnections(cfg.Instances)
 	childCtx, cancelFunc := context.WithCancel(context.Background())
-	go router.rebalanceLoop(childCtx)
 	router.cancelFunc = cancelFunc
+	go router.rebalanceLoop(childCtx)
 	return router, err
 }
 
-func (router *RandomRouter) initConnections(addrs []string) error {
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	router.mu.backends = make(map[string]*BackendWrapper)
-	if router.observer == nil {
-		logutil.BgLogger().Info("pd addr is not configured, use static backend instances instead.")
-		if len(addrs) == 0 {
-			return ErrNoInstanceToSelect
-		}
-		for _, addr := range addrs {
-			router.mu.backends[addr] = &BackendWrapper{
-				BackendInfo: BackendInfo{
-					status: StatusHealthy,
-				},
-				connList: list.New(),
-				connMap:  make(map[uint64]*list.Element),
-			}
-		}
-	}
-	return nil
-}
-
 func (router *RandomRouter) Route(conn driver.RedirectableConn) (string, error) {
-	addr, err := router.getLeastConnBackend()
-	if err != nil {
-		return addr, err
+	router.Lock()
+	defer router.Unlock()
+	be := router.backends.Back()
+	if be == nil {
+		return "", ErrNoInstanceToSelect
 	}
-	router.addConn(addr, conn)
-	conn.SetEventReceiver(router)
-	return addr, nil
-}
-
-func (router *RandomRouter) getLeastConnBackend() (string, error) {
-	leastConnNum := math.MaxInt
-	var leastConnAddr string
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	for addr, backend := range router.mu.backends {
-		if backend.status == StatusHealthy {
-			num := len(backend.connMap)
-			if num < leastConnNum {
-				leastConnNum = num
-				leastConnAddr = addr
-			}
-		}
-	}
-	if len(leastConnAddr) == 0 {
-		return leastConnAddr, ErrNoInstanceToSelect
-	}
-	return leastConnAddr, nil
-}
-
-func (router *RandomRouter) addConn(addr string, conn driver.RedirectableConn) {
-	connID := conn.ConnectionID()
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	backend, ok := router.mu.backends[addr]
-	if !ok {
-		// The backend may be just down and moved away.
-		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
-		return
+	backend := be.Value.(*BackendWrapper)
+	switch backend.status {
+	case StatusCannotConnect, StatusServerDown, StatusSchemaOutdated:
+		return "", ErrNoInstanceToSelect
 	}
 	connWrapper := &ConnWrapper{
 		RedirectableConn: conn,
 		phase:            phaseNotRedirected,
 	}
-	e := backend.connList.PushBack(connWrapper)
-	backend.connMap[connID] = e
+	router.addConn(be, connWrapper)
+	conn.SetEventReceiver(router)
+	return backend.addr, nil
+}
+
+func (router *RandomRouter) removeConn(be *list.Element, ce *list.Element) {
+	backend := be.Value.(*BackendWrapper)
+	conn := ce.Value.(*ConnWrapper)
+	backend.connList.Remove(ce)
+	delete(backend.connMap, conn.ConnectionID())
+	router.adjustBackendList(be)
+}
+
+func (router *RandomRouter) addConn(be *list.Element, conn *ConnWrapper) {
+	backend := be.Value.(*BackendWrapper)
+	ce := backend.connList.PushBack(conn)
+	backend.connMap[conn.ConnectionID()] = ce
+	router.adjustBackendList(be)
+}
+
+func (router *RandomRouter) adjustBackendList(be *list.Element) {
+	backend := be.Value.(*BackendWrapper)
+	curScore := backend.score()
+	var mark *list.Element
+	for ele := be.Prev(); ele != nil; ele = ele.Prev() {
+		b := ele.Value.(*BackendWrapper)
+		if b.score() >= curScore {
+			break
+		}
+		mark = ele
+	}
+	if mark != nil {
+		router.backends.MoveBefore(be, mark)
+		return
+	}
+	for ele := be.Next(); ele != nil; ele = ele.Next() {
+		b := ele.Value.(*BackendWrapper)
+		if b.score() <= curScore {
+			break
+		}
+		mark = ele
+	}
+	if mark != nil {
+		router.backends.MoveAfter(be, mark)
+	}
 }
 
 func (router *RandomRouter) RedirectConnections() error {
-	requests := make([]*RedirectRequest, 0)
-	router.mu.Lock()
-	for addr, backend := range router.mu.backends {
-		for e := backend.connList.Front(); e != nil; e = e.Next() {
-			requests = append(requests, &RedirectRequest{
-				from:   addr,
-				connID: e.Value.(*ConnWrapper).ConnectionID(),
-			})
+	router.Lock()
+	defer router.Unlock()
+	for be := router.backends.Front(); be != nil; be = be.Next() {
+		backend := be.Value.(*BackendWrapper)
+		for ce := backend.connList.Front(); ce != nil; ce = ce.Next() {
+			// This is only for test, so we allow it to reconnect to the same backend.
+			connWrapper := ce.Value.(*ConnWrapper)
+			if connWrapper.phase != phaseRedirectNotify {
+				connWrapper.phase = phaseRedirectNotify
+				connWrapper.Redirect(backend.addr)
+			}
 		}
-	}
-	router.mu.Unlock()
-	for _, request := range requests {
-		to, err := router.getLeastConnBackend()
-		if err != nil {
-			logutil.BgLogger().Warn("redirecting encounters an error", zap.Error(err))
-			break
-		}
-		// This is only for test, so we allow it to reconnect to the same backend.
-		router.notifyRedirect(request.from, to, request.connID)
 	}
 	return nil
 }
 
-func (router *RandomRouter) notifyRedirect(from, to string, connID uint64) {
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	originalBackend, ok := router.mu.backends[from]
-	if !ok {
-		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", from))
-		return
+func (router *RandomRouter) lookupBackend(addr string, forward bool) *list.Element {
+	if forward {
+		for be := router.backends.Front(); be != nil; be = be.Next() {
+			backend := be.Value.(*BackendWrapper)
+			if backend.addr == addr {
+				return be
+			}
+		}
+	} else {
+		for be := router.backends.Back(); be != nil; be = be.Prev() {
+			backend := be.Value.(*BackendWrapper)
+			if backend.addr == addr {
+				return be
+			}
+		}
 	}
-	newBackend, ok := router.mu.backends[to]
-	if !ok {
-		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
-		return
-	}
-	e, ok := originalBackend.connMap[connID]
-	if !ok {
-		// It may have been redirected or closed. It's fine, we can redirect it at next time if necessary.
-		return
-	}
-	if newBackend.status != StatusHealthy {
-		return
-	}
-	connWrapper := e.Value.(*ConnWrapper)
-	if connWrapper.phase == phaseRedirectNotify {
-		// We do not send concurrent signals.
-		return
-	}
-	originalBackend.connList.Remove(e)
-	delete(originalBackend.connMap, connID)
-	router.removeBackendIfEmpty(from, originalBackend)
-	connWrapper.phase = phaseRedirectNotify
-	e = newBackend.connList.PushBack(connWrapper)
-	newBackend.connMap[connID] = e
-	connWrapper.Redirect(to)
+	return nil
 }
 
 func (router *RandomRouter) OnRedirectSucceed(from, to string, conn driver.RedirectableConn) {
-	connID := conn.ConnectionID()
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	newBackend, ok := router.mu.backends[to]
-	if !ok {
-		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
+	router.Lock()
+	defer router.Unlock()
+	be := router.lookupBackend(to, false)
+	if be == nil {
+		// impossible here
 		return
 	}
-	e, ok := newBackend.connMap[connID]
+	toBackend := be.Value.(*BackendWrapper)
+	e, ok := toBackend.connMap[conn.ConnectionID()]
 	if !ok {
-		// Impossible here.
+		// impossible here
 		return
 	}
 	connWrapper := e.Value.(*ConnWrapper)
-	if connWrapper.phase != phaseRedirectNotify {
-		// Impossible here.
-		return
-	}
 	connWrapper.phase = phaseRedirectEnd
 }
 
 func (router *RandomRouter) OnRedirectFail(from, to string, conn driver.RedirectableConn) {
-	connID := conn.ConnectionID()
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	newBackend, ok := router.mu.backends[to]
+	router.Lock()
+	defer router.Unlock()
+	be := router.lookupBackend(to, false)
+	if be == nil {
+		// impossible here
+		return
+	}
+	toBackend := be.Value.(*BackendWrapper)
+	ce, ok := toBackend.connMap[conn.ConnectionID()]
 	if !ok {
-		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", to))
+		// impossible here
 		return
 	}
-	e, ok := newBackend.connMap[connID]
-	if !ok {
-		// Impossible here.
+	router.removeConn(be, ce)
+
+	be = router.lookupBackend(from, true)
+	// If the backend has already been removed, the connection is discarded from the router.
+	if be == nil {
 		return
 	}
-	connWrapper := e.Value.(*ConnWrapper)
-	if connWrapper.phase != phaseRedirectNotify {
-		// Impossible here.
-		return
-	}
+	connWrapper := ce.Value.(*ConnWrapper)
 	connWrapper.phase = phaseRedirectFail
-	newBackend.connList.Remove(e)
-	delete(newBackend.connMap, connID)
-	originalBackend, ok := router.mu.backends[from]
-	if !ok {
-		// The backend may have been removed already, then the connection is discarded from the router.
-		return
-	}
-	e = originalBackend.connList.PushBack(connWrapper)
-	originalBackend.connMap[connID] = e
+	router.addConn(be, connWrapper)
 }
 
 func (router *RandomRouter) OnConnClosed(addr string, conn driver.RedirectableConn) {
 	connID := conn.ConnectionID()
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	backend, ok := router.mu.backends[addr]
-	if !ok {
-		logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
+	router.Lock()
+	defer router.Unlock()
+	be := router.lookupBackend(addr, true)
+	if be != nil {
+		// impossible here
 		return
 	}
-	e, ok := backend.connMap[connID]
+	backend := be.Value.(*BackendWrapper)
+	ce, ok := backend.connMap[connID]
 	if !ok {
-		// Impossible here.
+		// impossible here
 		return
 	}
-	backend.connList.Remove(e)
-	delete(backend.connMap, connID)
-	router.removeBackendIfEmpty(addr, backend)
+	router.removeConn(be, ce)
+	router.removeBackendIfEmpty(be)
 }
 
-func (router *RandomRouter) OnBackendChanged(removed, added map[string]*BackendInfo) {
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	for addr, info := range removed {
-		logutil.BgLogger().Info("remove backend", zap.String("url", addr), zap.String("status", info.status.String()))
-		backend, ok := router.mu.backends[addr]
-		if !ok {
-			logutil.BgLogger().Error("no such address in backend info", zap.String("addr", addr))
-			continue
-		}
-		backend.BackendInfo = *info
-		router.removeBackendIfEmpty(addr, backend)
-	}
-	for addr, info := range added {
-		logutil.BgLogger().Info("add backend", zap.String("url", addr))
-		backend, ok := router.mu.backends[addr]
-		if !ok {
-			router.mu.backends[addr] = &BackendWrapper{
+func (router *RandomRouter) OnBackendChanged(backends map[string]*BackendInfo) {
+	router.Lock()
+	defer router.Unlock()
+	for addr, info := range backends {
+		be := router.lookupBackend(addr, true)
+		if be == nil {
+			logutil.BgLogger().Info("find new backend", zap.String("url", addr),
+				zap.String("status", info.status.String()))
+			be = router.backends.PushBack(&BackendWrapper{
 				BackendInfo: *info,
+				addr:        addr,
 				connList:    list.New(),
 				connMap:     make(map[uint64]*list.Element),
-			}
+			})
 		} else {
+			backend := be.Value.(*BackendWrapper)
+			logutil.BgLogger().Info("update backend", zap.String("url", addr),
+				zap.String("prev_status", backend.status.String()), zap.String("cur_status", info.status.String()))
 			backend.BackendInfo = *info
 		}
+		router.adjustBackendList(be)
+		router.removeBackendIfEmpty(be)
 	}
 }
 
 func (router *RandomRouter) rebalanceLoop(ctx context.Context) {
 	for {
-		requests := router.getStrayConns(rebalanceConnsPerLoop)
-		// If there are any homeless connections this loop, we move unbalanced connections
-		// in the next loop to simplify the logic.
-		if len(requests) == 0 {
-			requests = router.getUnbalancedConns(rebalanceConnsPerLoop)
-		}
-		if ctx.Err() != nil {
-			break
-		}
-		if len(requests) > 0 {
-			router.redirectConns(requests)
-		}
-
+		router.rebalance(rebalanceConnsPerLoop)
 		select {
 		case <-ctx.Done():
 			return
@@ -322,89 +270,46 @@ func (router *RandomRouter) rebalanceLoop(ctx context.Context) {
 	}
 }
 
-func (router *RandomRouter) getStrayConns(maxNum int) []*RedirectRequest {
-	requests := make([]*RedirectRequest, 0, maxNum)
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	for addr, backend := range router.mu.backends {
-		if backend.status != StatusHealthy {
-			for e := backend.connList.Front(); e != nil && len(requests) < maxNum; e = e.Next() {
-				id := e.Value.(*ConnWrapper).ConnectionID()
-				requests = append(requests, &RedirectRequest{
-					from:   addr,
-					connID: id,
-				})
+func (router *RandomRouter) rebalance(maxNum int) {
+	router.Lock()
+	defer router.Unlock()
+	for i := 0; i < maxNum; i++ {
+		var busiestEle *list.Element
+		for be := router.backends.Front(); be != nil; be = be.Next() {
+			backend := be.Value.(*BackendWrapper)
+			if backend.connList.Len() > 0 {
+				busiestEle = be
+				break
 			}
 		}
-		if len(requests) >= maxNum {
+		if busiestEle == nil {
 			break
 		}
-	}
-	return requests
-}
-
-func (router *RandomRouter) getUnbalancedConns(maxNum int) []*RedirectRequest {
-	var (
-		totalConns, totalBackends, maxConnNum int
-		maxConnAddr                           string
-	)
-	requests := make([]*RedirectRequest, 0, maxNum)
-	router.mu.Lock()
-	defer router.mu.Unlock()
-	for addr, backend := range router.mu.backends {
-		if backend.status == StatusHealthy {
-			totalBackends++
-			connNum := len(backend.connMap)
-			totalConns += connNum
-			if connNum > maxConnNum {
-				maxConnNum = connNum
-				maxConnAddr = addr
-			}
-		}
-	}
-	if totalBackends <= 1 || totalConns <= 1 {
-		return requests
-	}
-	avgConnNum := float64(totalConns) / float64(totalBackends)
-	threshold := int(avgConnNum*(1+rebalancePctThreshold)) + 1
-	// We only rebalance one overloaded backend at one time.
-	if maxConnNum > threshold {
-		if maxConnNum-threshold < maxNum {
-			maxNum = maxConnNum - threshold
-		}
-		backend := router.mu.backends[maxConnAddr]
-		for e := backend.connList.Front(); e != nil && len(requests) < maxNum; e = e.Next() {
-			id := e.Value.(*ConnWrapper).ConnectionID()
-			requests = append(requests, &RedirectRequest{
-				from:   maxConnAddr,
-				connID: id,
-			})
-		}
-	}
-	return requests
-}
-
-func (router *RandomRouter) redirectConns(requests []*RedirectRequest) {
-	for _, request := range requests {
-		to, err := router.getLeastConnBackend()
-		if err != nil {
-			// All instances are down. We don't log here because the logs will be too many.
+		busiestBackend := busiestEle.Value.(*BackendWrapper)
+		idlestEle := router.backends.Back()
+		idlestBackend := idlestEle.Value.(*BackendWrapper)
+		if float64(busiestBackend.score())/float64(idlestBackend.score()+1) <= rebalanceMaxScoreRatio {
 			break
 		}
-		if request.from == to {
-			continue
-		}
-		router.notifyRedirect(request.from, to, request.connID)
+		ce := busiestBackend.connList.Front()
+		router.removeConn(busiestEle, ce)
+		conn := ce.Value.(*ConnWrapper)
+		conn.phase = phaseRedirectNotify
+		router.addConn(idlestEle, conn)
+		conn.Redirect(idlestBackend.addr)
 	}
 }
 
-func (router *RandomRouter) removeBackendIfEmpty(addr string, backend *BackendWrapper) {
+func (router *RandomRouter) removeBackendIfEmpty(be *list.Element) {
+	backend := be.Value.(*BackendWrapper)
 	if (backend.status == StatusServerDown || backend.status == StatusCannotConnect) && backend.connList.Len() == 0 {
-		delete(router.mu.backends, addr)
+		router.backends.Remove(be)
 	}
 }
 
 func (router *RandomRouter) Close() {
+	router.Lock()
+	defer router.Unlock()
 	if router.cancelFunc != nil {
 		router.cancelFunc()
 		router.cancelFunc = nil

--- a/pkg/proxy/sessionmgr/backend/backend_conn_mgr.go
+++ b/pkg/proxy/sessionmgr/backend/backend_conn_mgr.go
@@ -202,6 +202,8 @@ func (mgr *BackendConnManager) tryRedirect(ctx context.Context) (err error) {
 	return
 }
 
+// Redirect redirects the current session to the newAddr. Note that the function should be very quick,
+// so it cannot wait for any events.
 func (mgr *BackendConnManager) Redirect(newAddr string) {
 	// We do not use `chan signalRedirect` to avoid blocking. We cannot discard the signal when it blocks,
 	// because only the latest signal matters.


### PR DESCRIPTION
In #21 , the Router rebalances connections when the number of connections on one backend exceeds the average connections * 1.1. However, assume there are already 9 backends and we scale one more out, then no connections are rebalanced, which is a bug.

In this PR, the Router maintains a list of backends sorted by the number of their connections. The Router will rebalance the connections when the biggest connection number is higher than the smallest number * 1.1.

Test:
![image](https://user-images.githubusercontent.com/29590578/169837694-6be24f40-4bbf-4594-91e1-3e9ce86ff53f.png)

I scaled out the cluster several times in this test. In the last time, when I scaled 9 instances to 10, the connections are still even.