### PR TITLE
router: skip checking health for static TiDB instances

### DIFF
--- a/pkg/proxy/router/backend_observer.go
+++ b/pkg/proxy/router/backend_observer.go
@@ -181,7 +181,8 @@ func (bo *BackendObserver) observeStaticAddrs(ctx context.Context) {
 				status: StatusHealthy,
 			}
 		}
-		bo.checkHealth(ctx, backendInfo)
+		// The status port is not configured, so we skip checking health now.
+		//bo.checkHealth(ctx, backendInfo)
 		bo.notifyIfChanged(backendInfo)
 	}
 }


### PR DESCRIPTION
Previously, `BackendObserver` checks the health of TiDB instances even for static instances. However, the status ports are not configured, so it's impossible to check the health.
In this PR, I skipped checking their health if they are static instances.