### PR TITLE
backend: fix redirection fails if the initial db is dropped during session

### DIFF
--- a/pkg/proxy/sessionmgr/backend/authenticator.go
+++ b/pkg/proxy/sessionmgr/backend/authenticator.go
@@ -414,3 +414,7 @@ func (auth *Authenticator) changeUser(request []byte) {
 	auth.dbname = string(hack.String(dbName))
 	// TODO: attrs
 }
+
+func (auth *Authenticator) updateCurrentDB(db string) {
+	auth.dbname = db
+}


### PR DESCRIPTION
In redirection, the Session Manager uses the original auth info to handshake with the new TiDB instance. The auth info includes db name and user name.
However, the user may change to another db and the original db may be dropped. In this case, the redirection may fail because the db is not found.
This PR uses the current db in the session states to connect to the new TiDB instance.